### PR TITLE
Property was not initialized which generated an error. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
   <img src="https://user-images.githubusercontent.com/7081446/178473472-c0c29ec5-762c-47de-9ed4-999e5ad6c70d.png" width="200px" position="center">
 </p>
 
+Temporary version of Buckaroo PHP SDK with support for older version of Guzzle and Monolog.
+
 # Buckaroo PHP SDK
 
 <p align="center">

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         "ext-json": "*",
         "ext-pcre": "*",
         "ext-fileinfo": "*",
-        "monolog/monolog": "^2.2",
-        "guzzlehttp/guzzle": "^7.0",
+        "monolog/monolog": "^1.27 || ^2.2",
+        "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5",
         "composer/ca-bundle": "^1.3",
         "vlucas/phpdotenv": "^5.4"
     },

--- a/src/Models/AdditionalParameters.php
+++ b/src/Models/AdditionalParameters.php
@@ -33,6 +33,10 @@ class AdditionalParameters extends Model
      */
     public function setProperties(?array $data)
     {
+        if(!empty($data) && !isset($this->AdditionalParameter))
+        {
+            $this->AdditionalParameter = [];
+        }
         foreach($data ?? array() as $name => $value)
         {
             $this->AdditionalParameter[] = array(


### PR DESCRIPTION
1) Buckaroo\Tests\Payments\IdealTest::it_creates_a_ideal_payment
Error: Typed property Buckaroo\Models\AdditionalParameters::$AdditionalParameter must not be accessed before initialization

It may be better to just initialize the AdditionalParameter property in the constructor or at the definition but i was not sure of this would break stuff. 