### PR TITLE
Push validator fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "buckaroo/sdk",
     "description": "Buckaroo payment SDK",
     "license": "MIT",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "type": "library",
     "require": {
         "php": ">=7.4|^8.0",

--- a/src/Handlers/HMAC/Hmac.php
+++ b/src/Handlers/HMAC/Hmac.php
@@ -50,7 +50,7 @@ abstract class Hmac
         {
             if (is_array($data))
             {
-                $data = json_encode($data, JSON_UNESCAPED_UNICODE);
+                $data = json_encode($data, JSON_UNESCAPED_UNICODE|JSON_PRESERVE_ZERO_FRACTION);
             }
 
             $md5 = md5($data, true);


### PR DESCRIPTION
Retaining the float during json_encode in the validator