### PR TITLE
Hotfix - default value in software header & additionalParameter fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "buckaroo/sdk",
     "description": "Buckaroo payment SDK",
     "license": "MIT",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "type": "library",
     "require": {
         "php": ">=7.4|^8.0",

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -137,11 +137,11 @@ abstract class Config implements Loggable
         $this->returnURL = $_ENV['BPE_RETURN_URL'] ?? $returnURL ?? '';
         $this->returnURLCancel = $_ENV['BPE_RETURN_URL_CANCEL'] ?? $returnURLCancel ?? '';
         $this->pushURL = $_ENV['BPE_PUSH_URL'] ?? $pushURL ?? '';
-        $this->platformName = $_ENV['PlatformName'] ?? $platformName ?? '';
-        $this->platformVersion = $_ENV['PlatformVersion'] ?? $platformVersion ?? '';
-        $this->moduleSupplier = $_ENV['ModuleSupplier'] ?? $moduleSupplier ?? '';
-        $this->moduleName = $_ENV['ModuleName'] ?? $moduleName ?? '';
-        $this->moduleVersion = $_ENV['ModuleVersion'] ?? $moduleVersion ?? '';
+        $this->platformName = $_ENV['PlatformName'] ?? $platformName ?? 'Empty Platform Name';
+        $this->platformVersion = $_ENV['PlatformVersion'] ?? $platformVersion ?? '1.0.0';
+        $this->moduleSupplier = $_ENV['ModuleSupplier'] ?? $moduleSupplier ?? 'Empty Module Supplier';
+        $this->moduleName = $_ENV['ModuleName'] ?? $moduleName ?? 'Empty Module name';
+        $this->moduleVersion = $_ENV['ModuleVersion'] ?? $moduleVersion ?? '1.0.0';
         $this->culture = $_ENV['Culture'] ?? $culture ?? '';
 
         $this->setLogger($logger ?? new DefaultLogger());

--- a/src/Models/AdditionalParameters.php
+++ b/src/Models/AdditionalParameters.php
@@ -25,7 +25,7 @@ class AdditionalParameters extends Model
     /**
      * @var array
      */
-    protected array $List;
+    protected array $AdditionalParameter;
 
     /**
      * @param array|null $data
@@ -35,7 +35,7 @@ class AdditionalParameters extends Model
     {
         foreach ($data ?? [] as $name => $value)
         {
-            $this->List[] = [
+            $this->AdditionalParameter[] = [
                 'Value' => $value,
                 'Name' => $name,
             ];

--- a/tests/Buckaroo/Payments/In3Test.php
+++ b/tests/Buckaroo/Payments/In3Test.php
@@ -51,7 +51,7 @@ class In3Test extends BuckarooTestCase
      * @return void
      * @test
      */
-    public function it_creates_a_afterpaydigiaccept_refund()
+    public function it_creates_a_in3_refund()
     {
         $response = $this->buckaroo->method('in3')->refund([
             'amountCredit' => 10,


### PR DESCRIPTION
Adding a default value in the software header, when leave empty if would produce a 500 error on some of the requests.