### PR TITLE
Additional parameter fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "buckaroo/sdk",
     "description": "Buckaroo payment SDK",
     "license": "MIT",
-    "version": "1.7.2",
+    "version": "1.7.3",
     "type": "library",
     "require": {
         "php": ">=7.4|^8.0",

--- a/src/Models/AdditionalParameters.php
+++ b/src/Models/AdditionalParameters.php
@@ -20,22 +20,48 @@
 
 namespace Buckaroo\Models;
 
+/**
+ *
+ */
 class AdditionalParameters extends Model
 {
     /**
      * @var array
      */
-    protected array $AdditionalParameter;
+    protected ?array $AdditionalParameter;
+
+    /**
+     * @var array
+     */
+    protected ?array $List;
+
+    /**
+     * @var bool
+     */
+    private bool $isDataRequest;
 
     /**
      * @param array|null $data
      * @return AdditionalParameters
      */
-    public function setProperties(?array $data)
+    public function setProperties(?array $data, $type = 'AdditionalParameter')
     {
+        if($data == null) {
+            if(isset($this->AdditionalParameter)) {
+                $data = $this->AdditionalParameter;
+            }
+
+            if(isset($this->List)) {
+                $data = $this->List;
+            }
+        }
+
+        $this->AdditionalParameter = null;
+        $this->List = null;
+
         foreach ($data ?? [] as $name => $value)
         {
-            $this->AdditionalParameter[] = [
+            $this->$type[] = [
                 'Value' => $value,
                 'Name' => $name,
             ];

--- a/src/Models/Payload/Payload.php
+++ b/src/Models/Payload/Payload.php
@@ -25,6 +25,9 @@ use Buckaroo\Models\ClientIP;
 use Buckaroo\Models\CustomParameters;
 use Buckaroo\Models\Model;
 
+/**
+ *
+ */
 class Payload extends Model
 {
     /**
@@ -141,5 +144,17 @@ class Payload extends Model
         }
 
         return parent::setProperties($data);
+    }
+
+    /**
+     * @return $this
+     */
+    public function isDataRequest()
+    {
+        if(isset($this->additionalParameters)) {
+            $this->additionalParameters->setProperties(null, 'List');
+        }
+
+        return $this;
     }
 }

--- a/src/PaymentMethods/BuckarooVoucher/BuckarooVoucher.php
+++ b/src/PaymentMethods/BuckarooVoucher/BuckarooVoucher.php
@@ -67,6 +67,8 @@ class BuckarooVoucher extends PayablePaymentMethod
      */
     public function getBalance(): TransactionResponse
     {
+        $this->isDataRequest = true;
+
         $data = new GetBalance($this->payload);
 
         $this->setPayPayload();
@@ -80,6 +82,8 @@ class BuckarooVoucher extends PayablePaymentMethod
      */
     public function create(): TransactionResponse
     {
+        $this->isDataRequest = true;
+
         $data = new Create($this->payload);
 
         $this->setPayPayload();
@@ -94,6 +98,8 @@ class BuckarooVoucher extends PayablePaymentMethod
      */
     public function deactivate(): TransactionResponse
     {
+        $this->isDataRequest = true;
+        
         $data = new Deactivate($this->payload);
 
         $this->setPayPayload();

--- a/src/PaymentMethods/BuckarooWallet/BuckarooWallet.php
+++ b/src/PaymentMethods/BuckarooWallet/BuckarooWallet.php
@@ -39,6 +39,8 @@ class BuckarooWallet extends PayablePaymentMethod
      */
     public function createWallet()
     {
+        $this->isDataRequest = true;
+
         $this->requiredConfigFields = ['currency'];
 
         $wallet = new Wallet($this->payload);
@@ -55,6 +57,8 @@ class BuckarooWallet extends PayablePaymentMethod
      */
     public function updateWallet()
     {
+        $this->isDataRequest = true;
+
         $wallet = new Wallet($this->payload);
 
         $this->setServiceList('Update', $wallet);
@@ -67,6 +71,8 @@ class BuckarooWallet extends PayablePaymentMethod
      */
     public function getInfo()
     {
+        $this->isDataRequest = true;
+
         $wallet = new Wallet($this->payload);
 
         $this->setServiceList('GetInfo', $wallet);
@@ -79,6 +85,8 @@ class BuckarooWallet extends PayablePaymentMethod
      */
     public function release()
     {
+        $this->isDataRequest = true;
+
         $relasePayload = new ReleasePayload($this->payload);
 
         $wallet = new Wallet($this->payload);

--- a/src/PaymentMethods/CreditManagement/CreditManagement.php
+++ b/src/PaymentMethods/CreditManagement/CreditManagement.php
@@ -42,6 +42,7 @@ class CreditManagement extends PaymentMethod implements Combinable
         $invoice = new Invoice($this->payload);
 
         $payPayload = new PayPayload($this->payload);
+        $payPayload->isDataRequest();
 
         $this->request->setPayload($payPayload);
 
@@ -55,6 +56,7 @@ class CreditManagement extends PaymentMethod implements Combinable
         $invoice = new Invoice($this->payload);
 
         $payPayload = new PayPayload($this->payload);
+        $payPayload->isDataRequest();
 
         $this->request->setPayload($payPayload);
 
@@ -68,6 +70,7 @@ class CreditManagement extends PaymentMethod implements Combinable
         $creditNote = new CreditNote($this->payload);
 
         $payPayload = new PayPayload($this->payload);
+        $payPayload->isDataRequest();
 
         $this->request->setPayload($payPayload);
 

--- a/src/PaymentMethods/Emandates/Emandates.php
+++ b/src/PaymentMethods/Emandates/Emandates.php
@@ -54,6 +54,7 @@ class Emandates extends PaymentMethod implements Combinable
         $mandate = new Mandate($this->payload);
 
         $payPayload = new PayPayload($this->payload);
+        $payPayload->isDataRequest();
 
         $this->request->setPayload($payPayload);
 
@@ -82,6 +83,7 @@ class Emandates extends PaymentMethod implements Combinable
         $mandate = new Mandate($this->payload);
 
         $payPayload = new PayPayload($this->payload);
+        $payPayload->isDataRequest();
 
         $this->request->setPayload($payPayload);
 
@@ -98,6 +100,7 @@ class Emandates extends PaymentMethod implements Combinable
         $mandate = new Mandate($this->payload);
 
         $payPayload = new PayPayload($this->payload);
+        $payPayload->isDataRequest();
 
         $this->request->setPayload($payPayload);
 

--- a/src/PaymentMethods/KlarnaKP/KlarnaKP.php
+++ b/src/PaymentMethods/KlarnaKP/KlarnaKP.php
@@ -46,6 +46,8 @@ class KlarnaKP extends PayablePaymentMethod
      */
     public function reserve(): TransactionResponse
     {
+        $this->isDataRequest = true;
+
         $reserve = new Payload($this->payload);
 
         $this->setServiceList('Reserve', $reserve);
@@ -60,6 +62,8 @@ class KlarnaKP extends PayablePaymentMethod
      */
     public function cancelReserve(): TransactionResponse
     {
+        $this->isDataRequest = true;
+
         $cancel = new Payload($this->payload);
 
         $this->setServiceList('CancelReservation', $cancel);
@@ -72,6 +76,8 @@ class KlarnaKP extends PayablePaymentMethod
      */
     public function updateReserve(): TransactionResponse
     {
+        $this->isDataRequest = true;
+
         $update = new Payload($this->payload);
 
         $this->setServiceList('UpdateReservation', $update);

--- a/src/PaymentMethods/Marketplaces/Marketplaces.php
+++ b/src/PaymentMethods/Marketplaces/Marketplaces.php
@@ -52,6 +52,7 @@ class Marketplaces extends PaymentMethod implements Combinable
         $serviceList = new ServiceList($this->payload);
 
         $payPayload = new PayPayload($this->payload);
+        $payPayload->isDataRequest();
 
         $this->request->setPayload($payPayload);
 

--- a/src/PaymentMethods/PayablePaymentMethod.php
+++ b/src/PaymentMethods/PayablePaymentMethod.php
@@ -24,6 +24,9 @@ use Buckaroo\Models\Model;
 use Buckaroo\Models\Payload\PayPayload;
 use Buckaroo\Models\Payload\RefundPayload;
 
+/**
+ *
+ */
 abstract class PayablePaymentMethod extends PaymentMethod
 {
     /**
@@ -34,6 +37,11 @@ abstract class PayablePaymentMethod extends PaymentMethod
      * @var string
      */
     protected string $refundModel = RefundPayload::class;
+
+    /**
+     * @var bool
+     */
+    protected bool $isDataRequest = false;
 
     /**
      * @param Model|null $model
@@ -84,6 +92,11 @@ abstract class PayablePaymentMethod extends PaymentMethod
     {
         $payPayload = new $this->payModel($this->payload);
 
+        if($this->isDataRequest)
+        {
+            $payPayload->isDataRequest();
+        }
+
         $this->request->setPayload($payPayload);
 
         return $this;
@@ -95,6 +108,11 @@ abstract class PayablePaymentMethod extends PaymentMethod
     protected function setRefundPayload()
     {
         $refundPayload = new $this->refundModel($this->payload);
+
+        if($this->isDataRequest)
+        {
+            $refundPayload->isDataRequest();
+        }
 
         $this->request->setPayload($refundPayload);
 

--- a/src/PaymentMethods/PaymentMethodFactory.php
+++ b/src/PaymentMethods/PaymentMethodFactory.php
@@ -96,7 +96,7 @@ class PaymentMethodFactory
         Surepay::class => ['surepay'],
         Subscriptions::class => ['subscriptions'],
         SEPA::class => ['sepadirectdebit', 'sepa'],
-        KBC::class => ['kbcpaymentbutton'],
+        KBC::class => ['kbc', 'kbcpaymentbutton'],
         Paypal::class => ['paypal'],
         PayPerEmail::class => ['payperemail'],
         PaymentInitiation::class => ['paymentinitiation','paybybank'],
@@ -110,7 +110,6 @@ class PaymentMethodFactory
         Przelewy24::class => ['przelewy24'],
         PointOfSale::class => ['pospayment'],
         Giropay::class => ['giropay'],
-        NoServiceSpecifiedPayment::class => ['noservice'],
         GiftCard::class => [
             'giftcard', 'westlandbon', 'babygiftcard', 'babyparkgiftcard',
             'beautywellness', 'boekenbon', 'boekenvoordeel',

--- a/src/PaymentMethods/iDealQR/iDealQR.php
+++ b/src/PaymentMethods/iDealQR/iDealQR.php
@@ -37,9 +37,12 @@ class iDealQR extends PaymentMethod
     public function generate()
     {
         $payPayload = new Payload($this->payload);
+        $payPayload->isDataRequest();
+
         $this->request->setPayload($payPayload);
 
         $generate = new Generate($this->payload);
+
         $this->setServiceList('Generate', $generate);
 
         return $this->dataRequest();

--- a/tests/Buckaroo/Payments/CreditManagementTest.php
+++ b/tests/Buckaroo/Payments/CreditManagementTest.php
@@ -317,7 +317,7 @@ class CreditManagementTest extends BuckarooTestCase
             'applyStartRecurrent' => 'False',
             'invoiceAmount' => 10.00,
             'invoiceAmountVAT' => 1.00,
-        'invoiceDate' => '2022-01-01',
+            'invoiceDate' => '2022-01-01',
             'dueDate' => '2030-01-01',
             'schemeKey' => '2amq34',
             'maxStepIndex' => 1,

--- a/tests/Buckaroo/Payments/IdealQRTest.php
+++ b/tests/Buckaroo/Payments/IdealQRTest.php
@@ -43,7 +43,7 @@ class IdealQRTest extends BuckarooTestCase
             'amount' => '1.00',
             'amountIsChangeable' => true,
             'expiration' => '2030-09-30',
-            'isProcessing' => false,
+            'isProcessing' => false
         ]);
 
         $this->assertTrue($response->isSuccess());

--- a/tests/Buckaroo/Payments/KlarnaKPTest.php
+++ b/tests/Buckaroo/Payments/KlarnaKPTest.php
@@ -110,6 +110,10 @@ class KlarnaKPTest extends BuckarooTestCase
                     'price' => '10.10',
                 ],
             ],
+            'additionalParameters' => [
+                'initiated_by_magento' => '1',
+                'service_action' => 'something',
+            ],
         ]);
 
         $this->assertTrue($response->isPendingProcessing());

--- a/tests/Buckaroo/Payments/SurepayTest.php
+++ b/tests/Buckaroo/Payments/SurepayTest.php
@@ -34,7 +34,7 @@ class SurepayTest extends BuckarooTestCase
             'bankAccount' => [
                 'iban' => 'NL13TEST0123456789',
                 'accountName' => 'John Doe',
-            ],
+            ]
         ]);
 
         $this->assertTrue($response->isSuccess());


### PR DESCRIPTION
The node in the additional parameter is different between a transaction and a data request call. The transaction request accepts "AdditionalParameter" and the data request accepts "List". On default, the payload will generate the payload for the transaction request. Whenever you use a data request with an additional parameter please call the method "isDataRequest" on a Payload object. Also, there is a isDataRequest property added so you can change the property in the payment class itself.