### PR TITLE
BA-134 Add default Stdout Logger

### DIFF
--- a/src/Handlers/Logging/DefaultLogger.php
+++ b/src/Handlers/Logging/DefaultLogger.php
@@ -37,7 +37,10 @@ class DefaultLogger implements Subject, LoggerInterface
      */
     public function __construct()
     {
-        $this->attach(new Monolog());
+        if (($_ENV['BPE_LOG'] ?? false) === 'true')
+        {
+            $this->attach(new Monolog());
+        }
 
         if (($_ENV['BPE_REPORT_ERROR'] ?? false) === 'true')
         {

--- a/tests/Buckaroo/Payments/KBCTest.php
+++ b/tests/Buckaroo/Payments/KBCTest.php
@@ -24,6 +24,8 @@ use Tests\Buckaroo\BuckarooTestCase;
 
 class KBCTest extends BuckarooTestCase
 {
+    protected array $paymentPayload;
+
     protected function setUp(): void
     {
         $this->paymentPayload = ([

--- a/tests/Buckaroo/Payments/SepaTest.php
+++ b/tests/Buckaroo/Payments/SepaTest.php
@@ -6,6 +6,8 @@ use Tests\Buckaroo\BuckarooTestCase;
 
 class SepaTest extends BuckarooTestCase
 {
+    protected array $paymentPayload;
+
     protected function setUp(): void
     {
         $this->paymentPayload = ([

--- a/tests/Buckaroo/Payments/SofortTest.php
+++ b/tests/Buckaroo/Payments/SofortTest.php
@@ -24,6 +24,8 @@ use Tests\Buckaroo\BuckarooTestCase;
 
 class SofortTest extends BuckarooTestCase
 {
+    protected array $paymentPayload;
+    
     protected function setUp(): void
     {
         $this->paymentPayload = ([


### PR DESCRIPTION
Adding BPE_LOG to the env variable. On default, no log is being printed out on the stdout. To enable stdout logging please add BPE_LOG=true to your env file.