### PR TITLE
BA-243-iDEAL-Processing-not-working-properly-therefore-create-a-separate-method-for-iDEAL-Processing

### DIFF
--- a/src/PaymentMethods/PaymentMethodFactory.php
+++ b/src/PaymentMethods/PaymentMethodFactory.php
@@ -27,6 +27,7 @@ use Buckaroo\PaymentMethods\KBC\KBC;
 use Buckaroo\PaymentMethods\iDin\iDin;
 use Buckaroo\PaymentMethods\SEPA\SEPA;
 use Buckaroo\PaymentMethods\iDeal\iDeal;
+use Buckaroo\PaymentMethods\iDealProcessing\iDealProcessing;
 use Buckaroo\PaymentMethods\MBWay\MBWay;
 use Buckaroo\PaymentMethods\Tinka\Tinka;
 use Buckaroo\Exceptions\BuckarooException;
@@ -92,7 +93,8 @@ class PaymentMethodFactory
             ],
         CreditClick::class => ['creditclick'],
         CreditManagement::class => ['credit_management'],
-        iDeal::class => ['ideal', 'idealprocessing'],
+        iDeal::class => ['ideal'],
+        iDealProcessing::class => ['idealprocessing'],
         iDealQR::class => ['ideal_qr'],
         iDin::class => ['idin'],
         In3::class => ['in3'],
@@ -120,7 +122,6 @@ class PaymentMethodFactory
         Przelewy24::class => ['przelewy24'],
         PointOfSale::class => ['pospayment'],
         Giropay::class => ['giropay'],
-        NoServiceSpecifiedPayment::class => ['noservice'],
         GiftCard::class => [
             'giftcard', 'westlandbon', 'babygiftcard', 'babyparkgiftcard',
             'beautywellness', 'boekenbon', 'boekenvoordeel',

--- a/src/PaymentMethods/iDealProcessing/Models/Pay.php
+++ b/src/PaymentMethods/iDealProcessing/Models/Pay.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please send an email
+ * to support@buckaroo.nl so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+
+namespace Buckaroo\PaymentMethods\iDealProcessing\Models;
+
+use Buckaroo\Models\ServiceParameter;
+
+class Pay extends ServiceParameter
+{
+    protected string $issuer;
+}

--- a/src/PaymentMethods/iDealProcessing/iDealProcessing.php
+++ b/src/PaymentMethods/iDealProcessing/iDealProcessing.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please send an email
+ * to support@buckaroo.nl so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+
+declare(strict_types=1);
+
+namespace Buckaroo\PaymentMethods\iDealProcessing;
+
+use Buckaroo\Exceptions\BuckarooException;
+use Buckaroo\Models\Model;
+use Buckaroo\PaymentMethods\iDealProcessing\Models\Pay;
+use Buckaroo\PaymentMethods\PayablePaymentMethod;
+use Buckaroo\Services\TraitHelpers\HasIssuers;
+use Buckaroo\Transaction\Response\TransactionResponse;
+
+class iDealProcessing extends PayablePaymentMethod
+{
+    use HasIssuers {
+        issuers as traitIssuers;
+    }
+
+    /**
+     * @var string
+     */
+    protected string $paymentName = 'idealprocessing';
+    /**
+     * @var array|string[]
+     */
+    protected array $requiredConfigFields = ['currency', 'returnURL', 'returnURLCancel', 'pushURL'];
+
+    /**
+     * @param Model|null $model
+     * @return TransactionResponse
+     */
+    public function pay(?Model $model = null)
+    {
+        return parent::pay($model ?? new Pay($this->payload));
+    }
+
+    /**
+     * @param Model|null $model
+     * @return TransactionResponse
+     */
+    public function payRemainder(?Model $model = null): TransactionResponse
+    {
+        return parent::payRemainder($model ?? new Pay($this->payload));
+    }
+
+    /**
+     * @return array
+     * @throws BuckarooException
+     */
+    public function issuers(): array
+    {
+        $this->serviceVersion = 2;
+
+        return $this->traitIssuers();
+    }
+}

--- a/tests/Buckaroo/Payments/IdealProcessingTest.php
+++ b/tests/Buckaroo/Payments/IdealProcessingTest.php
@@ -35,11 +35,9 @@ class CustomConfig extends Config
     }
 }
 
-class IdealTest extends BuckarooTestCase
+class IdealProcessingTest extends BuckarooTestCase
 {
     protected array $paymentPayload;
-    protected array $refundPayload;
-
     protected function setUp(): void
     {
         $this->paymentPayload = [
@@ -60,30 +58,15 @@ class IdealTest extends BuckarooTestCase
                 'service_action' => 'something',
             ],
         ];
-
-        $this->refundPayload = [
-            'invoice' => 'testinvoice 123', //Set invoice number of the transaction to refund
-            'originalTransactionKey' => '4E8BD922192746C3918BF4077CXXXXXX',
-            //Set transaction key of the transaction to refund
-            'amountCredit' => 1.23,
-            'clientIP' => [
-                'address' => '123.456.789.123',
-                'type' => 0,
-            ],
-            'additionalParameters' => [
-                'initiated_by_magento' => '1',
-                'service_action' => 'something',
-            ],
-        ];
     }
 
     /**
      * @return void
      * @test
      */
-    public function it_get_ideal_issuers()
+    public function it_get_idealprocessing_issuers()
     {
-        $response = $this->buckaroo->method('ideal')->issuers();
+        $response = $this->buckaroo->method('idealprocessing')->issuers();
 
         $this->assertIsArray($response);
         foreach ($response as $item)
@@ -98,20 +81,10 @@ class IdealTest extends BuckarooTestCase
      * @return void
      * @test
      */
-    public function it_creates_a_ideal_payment()
+    public function it_creates_a_idealprocessing_payment()
     {
-        $response = $this->buckaroo->method('ideal')->pay($this->paymentPayload);
+        $response = $this->buckaroo->method('idealprocessing')->pay($this->paymentPayload);
 
         $this->assertTrue($response->isPendingProcessing());
-    }
-
-    /**
-     * @test
-     */
-    public function it_creates_a_ideal_refund()
-    {
-        $response = $this->buckaroo->method('ideal')->refund($this->refundPayload);
-
-        $this->assertTrue($response->isFailed());
     }
 }


### PR DESCRIPTION
add Ideal Processing as separate payment method, also removed duplicte NoServiceSpecifiedPayment in $payments array