### PR TITLE
BA-493 Fix: HouseNumberAdditional to HouseNumberSuffix mapping

### DIFF
--- a/src/PaymentMethods/Subscriptions/Models/Subscription.php
+++ b/src/PaymentMethods/Subscriptions/Models/Subscription.php
@@ -29,6 +29,7 @@ use Buckaroo\Models\Email;
 use Buckaroo\Models\Person;
 use Buckaroo\Models\Phone;
 use Buckaroo\Models\ServiceParameter;
+use Buckaroo\PaymentMethods\Subscriptions\Service\ParameterKeys\AddressAdapter;
 use Buckaroo\PaymentMethods\Subscriptions\Service\ParameterKeys\CompanyAdapter;
 
 class Subscription extends ServiceParameter
@@ -96,9 +97,9 @@ class Subscription extends ServiceParameter
      */
     protected Phone $phone;
     /**
-     * @var Address
+     * @var AddressAdapter
      */
-    protected Address $address;
+    protected AddressAdapter $address;
     /**
      * @var Person
      */
@@ -247,13 +248,13 @@ class Subscription extends ServiceParameter
 
     /**
      * @param $address
-     * @return Address
+     * @return AddressAdapter
      */
     public function address($address = null)
     {
         if (is_array($address))
         {
-            $this->address = new Address($address);
+            $this->address = new AddressAdapter(new Address($address));
         }
 
         return $this->address;

--- a/src/PaymentMethods/Subscriptions/Service/ParameterKeys/AddressAdapter.php
+++ b/src/PaymentMethods/Subscriptions/Service/ParameterKeys/AddressAdapter.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please send an email
+ * to support@buckaroo.nl so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+
+namespace Buckaroo\PaymentMethods\Subscriptions\Service\ParameterKeys;
+
+use Buckaroo\Models\Adapters\ServiceParametersKeysAdapter;
+
+class AddressAdapter extends ServiceParametersKeysAdapter
+{
+    protected array $keys = [
+        'houseNumberAdditional' => 'HouseNumberSuffix',
+    ];
+}

--- a/tests/Buckaroo/Payments/SubscriptionsTest.php
+++ b/tests/Buckaroo/Payments/SubscriptionsTest.php
@@ -96,6 +96,7 @@ class SubscriptionsTest extends BuckarooTestCase
             'address' => [
                 'street' => 'Hoofdstraat',
                 'houseNumber' => '90',
+                'houseNumberAdditional' => 'a',
                 'zipcode' => '8441ER',
                 'city' => 'Heerenveen',
                 'country' => 'NL',


### PR DESCRIPTION
Fixed that `HouseNumberAdditional` was not mapped correctly to `HouseNumberSuffix` in `CreateSubscription` request payload.