### PR TITLE
BA-591: add ArticleProductUrl and ArticleImageUrl Parameters to KlarnaKP

### DIFF
--- a/src/PaymentMethods/KlarnaKP/Models/Article.php
+++ b/src/PaymentMethods/KlarnaKP/Models/Article.php
@@ -18,20 +18,10 @@
  * @license   https://tldrlegal.com/license/mit-license
  */
 
-namespace Buckaroo\PaymentMethods\KlarnaKP\Service\ParameterKeys;
+namespace Buckaroo\PaymentMethods\KlarnaKP\Models;
 
-use Buckaroo\Models\Adapters\ServiceParametersKeysAdapter;
-
-class ArticleAdapter extends ServiceParametersKeysAdapter
+class Article extends \Buckaroo\Models\Article
 {
-    protected array $keys = [
-        'type' => 'ArticleType',
-        'description' => 'ArticleTitle',
-        'identifier' => 'ArticleNumber',
-        'price' => 'ArticlePrice',
-        'quantity' => 'ArticleQuantity',
-        'vatPercentage' => 'ArticleVat',
-        'imageUrl' => 'ArticleImageUrl',
-        'productUrl' => 'ArticleProductUrl',
-    ];
+    protected ?string $imageUrl;
+    protected ?string $productUrl;
 }

--- a/src/PaymentMethods/KlarnaKP/Models/Payload.php
+++ b/src/PaymentMethods/KlarnaKP/Models/Payload.php
@@ -20,7 +20,6 @@
 
 namespace Buckaroo\PaymentMethods\KlarnaKP\Models;
 
-use Buckaroo\Models\Article;
 use Buckaroo\Models\ServiceParameter;
 use Buckaroo\PaymentMethods\KlarnaKP\Service\ParameterKeys\ArticleAdapter;
 use Buckaroo\PaymentMethods\Traits\CountableGroupKey;

--- a/tests/Buckaroo/Payments/KlarnaKPTest.php
+++ b/tests/Buckaroo/Payments/KlarnaKPTest.php
@@ -111,6 +111,8 @@ class KlarnaKPTest extends BuckarooTestCase
                     'vatPercentage' => '21',
                     'quantity' => '2',
                     'price' => '20.10',
+                    'imageUrl' => 'https://example.com/image',
+                    'productUrl' => 'https://example.com/product',
                 ],
                 [
                     'identifier' => 'Articlenumber2',
@@ -118,6 +120,8 @@ class KlarnaKPTest extends BuckarooTestCase
                     'vatPercentage' => '21',
                     'quantity' => '1',
                     'price' => '10.10',
+                    'imageUrl' => 'https://example.com/image',
+                    'productUrl' => 'https://example.com/product',
                 ],
             ],
         ]);
@@ -143,6 +147,7 @@ class KlarnaKPTest extends BuckarooTestCase
     private function getPaymentPayload(?array $additional = null): array
     {
         $payload = [
+            'clientIP' => '198.162.1.1',
             'currency' => 'EUR',
             'amountDebit' => 50.30,
             'order' => uniqid(),
@@ -187,6 +192,8 @@ class KlarnaKPTest extends BuckarooTestCase
                     'vatPercentage' => '21',
                     'quantity' => '2',
                     'price' => '20.10',
+                    'imageUrl' => 'https://example.com/image',
+                    'productUrl' => 'https://example.com/product',
                 ],
                 [
                     'identifier' => 'Articlenumber2',
@@ -194,6 +201,8 @@ class KlarnaKPTest extends BuckarooTestCase
                     'vatPercentage' => '21',
                     'quantity' => '1',
                     'price' => '10.10',
+                    'imageUrl' => 'https://example.com/image',
+                    'productUrl' => 'https://example.com/product',
                 ],
             ]
         ];


### PR DESCRIPTION
Add optional ArticleProductUrl and ArticleImageUrl parameters to the Klarna SDK to include product images and URLs.