### PR TITLE
BP-3594 - B2B Orders don't work with DHL shipping module for BNPL methods

### DIFF
--- a/src/Models/Company.php
+++ b/src/Models/Company.php
@@ -25,5 +25,5 @@ class Company extends Person
     protected string $companyName;
     protected bool $vatApplicable;
     protected string $vatNumber;
-    protected string $chamberOfCommerce;
+    protected ?string $chamberOfCommerce;
 }


### PR DESCRIPTION
We are encountering merchants who use a pickup location as their shipping method. In such cases, the payload will display the company name as the address. However, the Chamber of Commerce information is unknown in these situations, so this property can be set to null.
