### PR TITLE
BA-628 - Ensure consistent UTF-8 encoding in base64Data function to correct hash values

### DIFF
--- a/src/Handlers/HMAC/Hmac.php
+++ b/src/Handlers/HMAC/Hmac.php
@@ -28,8 +28,7 @@ abstract class Hmac
      */
     public function uri($uri = null)
     {
-        if ($uri)
-        {
+        if ($uri) {
             $uri = preg_replace("#^[^:/.]*[:/]+#i", "", $uri);
 
             $this->uri = strtolower(urlencode($uri));
@@ -46,11 +45,13 @@ abstract class Hmac
     {
         $this->base64Data = '';
 
-        if ($data)
-        {
-            if (is_array($data))
-            {
-                $data = json_encode($data, JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION);
+        if ($data) {
+            if (is_array($data)) {
+                $data = mb_convert_encoding(
+                    json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+                    'UTF-8',
+                    'auto'
+                );
             }
 
             $md5 = md5($data, true);
@@ -67,8 +68,7 @@ abstract class Hmac
      */
     public function nonce($nonce = null)
     {
-        if ($nonce)
-        {
+        if ($nonce) {
             $this->nonce = $nonce;
         }
 
@@ -81,8 +81,7 @@ abstract class Hmac
      */
     public function time($time = null)
     {
-        if ($time)
-        {
+        if ($time) {
             $this->time = $time;
         }
 

--- a/src/Handlers/HMAC/Hmac.php
+++ b/src/Handlers/HMAC/Hmac.php
@@ -28,7 +28,8 @@ abstract class Hmac
      */
     public function uri($uri = null)
     {
-        if ($uri) {
+        if ($uri)
+        {
             $uri = preg_replace("#^[^:/.]*[:/]+#i", "", $uri);
 
             $this->uri = strtolower(urlencode($uri));
@@ -45,8 +46,10 @@ abstract class Hmac
     {
         $this->base64Data = '';
 
-        if ($data) {
-            if (is_array($data)) {
+        if ($data)
+        {
+            if (is_array($data))
+            {
                 $data = mb_convert_encoding(
                     json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
                     'UTF-8',
@@ -68,7 +71,8 @@ abstract class Hmac
      */
     public function nonce($nonce = null)
     {
-        if ($nonce) {
+        if ($nonce)
+        {
             $this->nonce = $nonce;
         }
 
@@ -81,7 +85,8 @@ abstract class Hmac
      */
     public function time($time = null)
     {
-        if ($time) {
+        if ($time)
+        {
             $this->time = $time;
         }
 


### PR DESCRIPTION
The base64Data function was returning incorrect Base64-encoded MD5 hash values due to inconsistent character encoding of the input data. Without enforcing UTF-8 encoding, the MD5 hash computed could differ from expected values

