### PR TITLE
BA-558 Update tests

### DIFF
--- a/tests/Buckaroo/BuckarooTestCase.php
+++ b/tests/Buckaroo/BuckarooTestCase.php
@@ -22,29 +22,21 @@ namespace Tests\Buckaroo;
 
 use Buckaroo\BuckarooClient;
 use Buckaroo\Config\DefaultConfig;
+use Buckaroo\Resources\Constants\Gender;
 use Dotenv\Dotenv;
 use PHPUnit\Framework\TestCase;
 
 class BuckarooTestCase extends TestCase
 {
     protected BuckarooClient $buckaroo;
+    protected static ?string $payTransactionKey = null;
+    protected static ?string $authorizeTransactionKey = null;
+
     public function __construct()
     {
         $dotenv = Dotenv::createImmutable(getcwd());
         $dotenv->load();
 
-//        $this->buckaroo = new BuckarooClient($_ENV['BPE_WEBSITE_KEY'], $_ENV['BPE_SECRET_KEY']);
-//
-//        ?string $mode = null,
-//        ?string $currency = null,
-//        ?string $returnURL = null,
-//        ?string $returnURLCancel = null,
-//        ?string $pushURL = null,
-//        ?string $platformName = null,
-//        ?string $moduleSupplier = null,
-//        ?string $moduleName = null,
-//        ?string $moduleVersion = null,
-        
         $this->buckaroo = new BuckarooClient(new DefaultConfig(
             $_ENV['BPE_WEBSITE_KEY'],
             $_ENV['BPE_SECRET_KEY'],
@@ -62,5 +54,213 @@ class BuckarooTestCase extends TestCase
         ));
 
         parent::__construct();
+    }
+
+    protected function getPayPayload(?array $overrides = []): array
+    {
+        $payload = [
+            'billing' => $this->getBillingPayload(),
+            'shipping' => $this->getShippingPayload(),
+        ];
+
+        return array_merge($this->getBasePayPayload(), $payload, $overrides);
+    }
+
+    protected function getRefundPayload(?array $overrides = []): array
+    {
+        $payload = [
+            'amountCredit' => 0.01,
+            'invoice' => uniqid(),
+        ];
+        return array_merge($payload, $overrides);
+    }
+
+    protected function getBasePayPayload(?array $exceptKeys = [], ?array $overrides = []): array
+    {
+        $payload =  [
+            'clientIP' => '127.0.0.1',
+            'invoice' => uniqid(),
+            'currency' => 'EUR',
+            'amountDebit' => 100.30,
+            'order' => uniqid(),
+            'description' => 'Buckaroo SDK Test Transaction',
+        ];
+
+        if ($exceptKeys) {
+            foreach ($exceptKeys as $key) {
+                $this->removeKeyFromArray($payload, $key);
+            }
+        }
+
+        return array_merge($payload, $overrides);
+    }
+
+    protected function getBillingPayload(?array $exceptKeys = [], ?array $overrides = []): array
+    {
+        $payload =  [
+            'recipient' => [
+                'category' => 'B2C',
+                'title' => 'Female',
+                'careOf' => 'John Smith',
+                'firstName' => 'John',
+                'lastName' => 'Doe',
+                'initials' => 'JD',
+                'salutation' => 'Male',
+                'birthDate' => '1990-01-01',
+                'companyName' => 'Buckaroo Test',
+                'email' => 'test@buckaroo.nl',
+                'phone' => ['mobile' => '0698765433'],
+                'conversationLanguage' => 'NL',
+                'identificationNumber' => 'IdNumber12345',
+                'customerNumber' => 'customerNumber12345',
+            ],
+            'address' => [
+                'street' => 'Hoofdstraat',
+                'houseNumber' => '13',
+                'houseNumberSuffix' => 'A',
+                'zipcode' => '1234AB',
+                'city' => 'Heerenveen',
+                'country' => 'NL',
+            ],
+            'phone' => ['mobile' => '0698765433'],
+            'email' => 'test@buckaroo.nl',
+        ];
+
+        if ($exceptKeys) {
+            foreach ($exceptKeys as $key) {
+                $this->removeKeyFromArray($payload, $key);
+            }
+        }
+
+        return array_merge($payload, $overrides);
+    }
+
+    protected function getShippingPayload(?array $exceptKeys = [], ?array $overrides = []): array
+    {
+        $payload =  [
+            'recipient' => [
+                'category' => 'B2C',
+                'careOf' => 'John Smith',
+                'title' => 'Male',
+                'initials' => 'JD',
+                'salutation' => 'Male',
+                'companyName' => 'Buckaroo B.V.',
+                'firstName' => 'John',
+                'lastName' => 'Doe',
+                'birthDate' => '1990-01-01',
+                'phone' => ['mobile' => '0698765433'],
+                'email' => 'test@buckaroo.nl',
+                'conversationLanguage' => 'NL',
+                'identificationNumber' => 'IdNumber12345',
+                'customerNumber' => 'customerNumber12345',
+            ],
+            'email' => 'test@buckaroo.nl',
+            'address' => [
+                'street' => 'Kalverstraat',
+                'houseNumber' => '13',
+                'houseNumberSuffix' => 'A',
+                'zipcode' => '4321EB',
+                'city' => 'Amsterdam',
+                'country' => 'NL',
+                'addressType' => 'Standard'
+            ],
+        ];
+
+        if ($exceptKeys) {
+            foreach ($exceptKeys as $key) {
+                $this->removeKeyFromArray($payload, $key);
+            }
+        }
+
+        return array_merge($payload, $overrides);
+    }
+
+    private function removeKeyFromArray(array &$array, $keyToRemove): void
+    {
+        foreach ($array as $key => &$value) {
+            if ($key === $keyToRemove) {
+                unset($array[$key]);
+            } elseif (is_array($value)) {
+                $this->removeKeyFromArray($value, $keyToRemove);
+            }
+        }
+    }
+
+    protected function getArticlesPayload(?array $exceptKeys = [], ?array $overrides = []): array
+    {
+        $payload = [
+            [
+                'identifier' => 'Articlenumber1',
+                'description' => 'Blue Toy Car',
+                'vatPercentage' => '21',
+                'quantity' => '2',
+                'price' => '25.10',
+                'imageUrl' => 'https://www.buckaroo.nl/img/logo_menu.png',
+                'UnitCode' => 'Pieces'
+            ],
+            [
+                'identifier' => 'Articlenumber2',
+                'description' => 'Red Toy Car',
+                'vatPercentage' => '21',
+                'quantity' => '1',
+                'price' => '50.10',
+                'imageUrl' => 'https://www.buckaroo.nl/img/logo_menu.png',
+                'UnitCode' => 'Pieces'
+            ],
+        ];
+
+        if ($exceptKeys) {
+            foreach ($exceptKeys as $key) {
+                $this->removeKeyFromArray($payload, $key);
+            }
+        }
+
+        return array_merge($payload, $overrides);
+    }
+
+    protected function getInvoicePayload(array $append = []): array
+    {
+        return array_merge($append, [
+            'applyStartRecurrent' => 'False',
+            'invoiceAmount' => 10.00,
+            'invoiceAmountVAT' => 1.00,
+            'invoiceDate' => '2024-01-01',
+            'dueDate' => '2030-01-01',
+            'schemeKey' => 'DefaultNone',
+            'maxStepIndex' => 1,
+            'allowedServices' => 'ideal,mastercard',
+            'debtor' => [
+                'code' => 'johnsmith4',
+            ],
+            'email' => 'youremail@example.nl',
+            'phone' => [
+                'mobile' => '06198765432',
+            ],
+            'person' => [
+                'culture' => 'nl-NL',
+                'title' => 'Msc',
+                'initials' => 'JS',
+                'firstName' => 'Test',
+                'lastNamePrefix' => 'Jones',
+                'lastName' => 'Aflever',
+                'gender' => Gender::MALE,
+            ],
+            'company' => [
+                'culture' => 'nl-NL',
+                'name' => 'My Company Corporation',
+                'vatApplicable' => true,
+                'vatNumber' => 'NL140619562B01',
+                'chamberOfCommerce' => '20091741',
+            ],
+            'address' => [
+                'street' => 'Hoofdtraat',
+                'houseNumber' => '90',
+                'houseNumberSuffix' => 'A',
+                'zipcode' => '8441ER',
+                'city' => 'Heerenveen',
+                'state' => 'Friesland',
+                'country' => 'NL',
+            ],
+        ]);
     }
 }

--- a/tests/Buckaroo/BuckarooTestCase.php
+++ b/tests/Buckaroo/BuckarooTestCase.php
@@ -226,9 +226,10 @@ class BuckarooTestCase extends TestCase
             'invoiceAmountVAT' => 1.00,
             'invoiceDate' => '2024-01-01',
             'dueDate' => '2030-01-01',
-            'schemeKey' => 'DefaultNone',
+            'schemeKey' => 's31w5d',
             'maxStepIndex' => 1,
             'allowedServices' => 'ideal,mastercard',
+            'allowedServicesAfterDueDate' => 'ideal,mastercard',
             'debtor' => [
                 'code' => 'johnsmith4',
             ],

--- a/tests/Buckaroo/Payments/AfterpayTest.php
+++ b/tests/Buckaroo/Payments/AfterpayTest.php
@@ -33,6 +33,8 @@ class AfterpayTest extends BuckarooTestCase
     {
         $response = $this->buckaroo->method('afterpay')->setServiceVersion(3)->pay($this->getPaymentPayload());
 
+        self::$payTransactionKey = $response->getTransactionKey();
+
         $this->assertTrue($response->isSuccess());
     }
 
@@ -44,145 +46,94 @@ class AfterpayTest extends BuckarooTestCase
     {
         $response = $this->buckaroo->method('afterpay')->authorize($this->getPaymentPayload());
 
+        self::$authorizeTransactionKey = $response->getTransactionKey();
+
         $this->assertTrue($response->isSuccess());
     }
 
     /**
      * @return void
      * @test
+     * @depends it_creates_a_afterpay_authorize
+     */
+    public function it_creates_a_afterpay_cancelAuthorize()
+    {
+        if (empty(self::$authorizeTransactionKey)) {
+            $this->markTestSkipped('Skipping cancelAuthorize: No authorization transaction key is set.');
+        }
+
+        $response = $this->buckaroo->method('afterpay')->cancelAuthorize($this->getPaymentPayload([
+            'originalTransactionKey' => self::$authorizeTransactionKey,
+            'amountCredit' => 100.30,
+        ]));
+
+        $this->assertTrue($response->isSuccess());
+    }
+
+    /**
+     * @return void
+     * @test
+     * @depends it_creates_a_afterpay_authorize
      */
     public function it_creates_a_afterpay_capture()
     {
+        $response = $this->buckaroo->method('afterpay')->setServiceVersion(3)->authorize($this->getPaymentPayload());
+
+        $this->assertTrue($response->isSuccess());
+
         $response = $this->buckaroo->method('afterpay')->capture($this->getPaymentPayload([
-            'originalTransactionKey' => 'D5127080BA1D4644856FECDC560FXXXX',
+            'originalTransactionKey' => $response->getTransactionKey(),
+            'amountCredit' => 100.30,
         ]));
 
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isSuccess());
     }
 
     /**
      * @return void
      * @test
+     * @depends it_creates_a_afterpay_payment
      */
     public function it_creates_a_afterpay_refund()
     {
-        $response = $this->buckaroo->method('afterpay')->refund([
-            'invoice' => 'testinvoice 123', //Set invoice number of the transaction to refund
-            'originalTransactionKey' => '4E8BD922192746C3918BF4077CXXXXXX',
-            //Set transaction key of the transaction to refund
-            'amountCredit' => 1.23,
-        ]);
+        if (empty(self::$payTransactionKey)) {
+            $this->markTestSkipped('Skipping refund: No original transaction key is set.');
+        }
 
-        $this->assertTrue($response->isValidationFailure());
-    }
-
-    /**
-     * @return void
-     * @test
-     */
-    public function it_creates_a_afterpay_partial_refund()
-    {
-        $response = $this->buckaroo->method('afterpay')->refund([
-            'invoice' => 'testinvoice 123', //Set invoice number of the transaction to refund
-            'originalTransactionKey' => '4E8BD922192746C3918BF4077CXXXXXX',
-            //Set transaction key of the transaction to refund
-            'amountCredit' => 1.23,
-            'articles' => [
-                [
-                    'refundType' => 'Return',
-                    'identifier' => 'Articlenumber1',
-                    'description' => 'Blue Toy Car',
-                    'vatPercentage' => '21',
-                    'quantity' => '2',
-                    'price' => '20.10',
+        $response = $this->buckaroo->method('afterpay')->refund(
+            $this->getRefundPayload([
+                'originalTransactionKey' => self::$payTransactionKey,
+                'amountCredit' => 50.20,
+                'articles' => [
+                    [
+                        'refundType' => 'Return',
+                        'identifier' => 'Articlenumber1',
+                        'description' => 'Blue Toy Car',
+                        'vatPercentage' => '21',
+                        'quantity' => '2',
+                        'price' => '25.10',
+                    ],
                 ],
-            ],
-        ]);
+            ])
+        );
 
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isSuccess());
     }
 
     private function getPaymentPayload(?array $additional = null): array
     {
-        $payload = [
-            'amountDebit'       => 52.30,
-            'order'             => uniqid(),
-            'invoice'           => uniqid(),
-            'clientIP'      => '127.0.0.1',
-            'billing'       => [
-                'recipient'        => [
-                    'category'      => RecipientCategory::COMPANY,
-                    'careOf'        => 'John Smith',
-                    'title'            => 'Mrs',
-                    'firstName'      => 'John',
-                    'lastName'      => 'Do',
-                    'birthDate'     => '1990-01-01',
-                    'companyName' => 'buckarooTest',
-                    'conversationLanguage'  => 'NL',
-                    'chamberOfCommerce'  => 'IdNumber12345',
-                    'customerNumber'        => 'customerNumber12345'
-                ],
-                'address' => [
-                    'street' => 'Hoofdstraat',
-                    'houseNumber' => '13',
-                    'houseNumberAdditional' => 'a',
-                    'zipcode' => '1234AB',
-                    'city' => 'Heerenveen',
-                    'country' => 'NL',
-                ],
-                'phone' => [
-                    'mobile' => '0698765433',
-                    'landline' => '0109876543',
-                ],
-                'email' => 'test@buckaroo.nl',
-            ],
-            'shipping' => [
-                'recipient' => [
-                    'category' => RecipientCategory::COMPANY,
-                    'careOf' => 'John Smith',
-                    'companyName' => 'Buckaroo B.V.',
-                    'firstName' => 'John',
-                    'lastName' => 'Do',
-                    'chamberOfCommerce' => '12345678',
-                ],
-                'address' => [
-                    'street' => 'Kalverstraat',
-                    'houseNumber' => '13',
-                    'houseNumberAdditional' => 'b',
-                    'zipcode' => '4321EB',
-                    'city' => 'Amsterdam',
-                    'country' => 'NL',
-                ],
-            ],
-            'articles' => [
-                [
-                    'identifier' => 'Articlenumber1',
-                    'description' => 'Blue Toy Car',
-                    'vatPercentage' => '21',
-                    'quantity' => '2',
-                    'price' => '20.10',
-                ],
-                [
-                    'identifier' => 'Articlenumber2',
-                    'description' => 'Red Toy Car',
-                    'vatPercentage' => '21',
-                    'quantity' => '1',
-                    'price' => '10.10',
-                ],
-                [
-                    'type'      => 'ShippingFee',
-                    'identifier' => 'USPShippingID',
-                    'description' => 'UPS',
-                    'vatPercentage' => '21',
-                    'quantity' => '1',
-                    'price' => '2'
-                ],
-            ]
-        ];
+        $payload = array_merge($this->getBasePayPayload(), [
+            'billing' => $this->getBillingPayload(['initials', 'title', 'companyName']),
+            'shipping' => $this->getShippingPayload(['initials', 'title', 'companyName']),
+            'articles' => $this->getArticlesPayload(),
+        ]);
 
-        if ($additional)
-        {
-            return array_merge($additional, $payload);
+        $payload['billing']['recipient']['category'] = RecipientCategory::PERSON;
+        $payload['shipping']['recipient']['category'] = RecipientCategory::PERSON;
+
+
+        if ($additional) {
+            $payload = array_merge($additional, $payload);
         }
 
         return $payload;

--- a/tests/Buckaroo/Payments/AlipayTest.php
+++ b/tests/Buckaroo/Payments/AlipayTest.php
@@ -30,11 +30,32 @@ class AlipayTest extends BuckarooTestCase
      */
     public function it_creates_a_alipay_payment()
     {
-        $response = $this->buckaroo->method('alipay')->pay([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
+        $response = $this->buckaroo->method('alipay')->pay($this->getBasePayPayload([], [
             'useMobileView' => true,
-        ]);
+        ]));
+
+        $this->assertTrue($response->isPendingProcessing());
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_a_alipay_pay_remainder()
+    {
+        $giftCardResponse = $this->buckaroo->method('giftcard')->pay($this->getBasePayPayload([], [
+            'amountDebit' => 10,
+            'name' => 'boekenbon',
+            'intersolveCardnumber' => '0000000000000000001',
+            'intersolvePIN' => '500',
+        ]));
+
+        $this->assertTrue($giftCardResponse->isSuccess());
+
+        $response = $this->buckaroo->method('alipay')->payRemainder($this->getBasePayPayload([], [
+            'originalTransactionKey' => $giftCardResponse->data('RelatedTransactions')[0]['RelatedTransactionKey'],
+            'amountDebit' => 9.50,
+            'useMobileView' => true,
+        ]));
 
         $this->assertTrue($response->isPendingProcessing());
     }
@@ -44,12 +65,10 @@ class AlipayTest extends BuckarooTestCase
      */
     public function it_creates_a_alipay_refund()
     {
-        $response = $this->buckaroo->method('alipay')->refund([
-            'amountCredit' => 10,
-            'invoice' => 'testinvoice 123',
-            'originalTransactionKey' => '2D04704995B74D679AACC59F87XXXXXX',
-        ]);
+        $response = $this->buckaroo->method('alipay')->refund($this->getRefundPayload([
+            'originalTransactionKey' => 'CF16AD6BAB2F4B0C8C435654AE5E5740',
+        ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/BancontactTest.php
+++ b/tests/Buckaroo/Payments/BancontactTest.php
@@ -30,11 +30,9 @@ class BancontactTest extends BuckarooTestCase
      */
     public function it_creates_a_bancontact_payment()
     {
-        $response = $this->buckaroo->method('bancontactmrcash')->pay([
-            'invoice' => uniqid(),
-            'amountDebit' => 10.10,
+        $response = $this->buckaroo->method('bancontactmrcash')->pay($this->getBasePayPayload([],[
             'saveToken' => true,
-        ]);
+        ]));
 
         $this->assertTrue($response->isWaitingOnUserInput());
     }
@@ -44,13 +42,11 @@ class BancontactTest extends BuckarooTestCase
      */
     public function it_creates_a_bancontact_refund()
     {
-        $response = $this->buckaroo->method('bancontactmrcash')->refund([
-            'amountCredit' => 10,
-            'invoice' => '10000480',
-            'originalTransactionKey' => '0EF39AA94BD64FF38F1540DEB6XXXXXX',
-        ]);
+        $response = $this->buckaroo->method('bancontactmrcash')->refund($this->getRefundPayload([
+            'originalTransactionKey' => '77FDD0E0CF9C4AF1B85CEA2942DE27DC',
+        ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 
     /**
@@ -59,15 +55,12 @@ class BancontactTest extends BuckarooTestCase
      */
     public function it_creates_a_bancontact_encrypted_payment()
     {
-        $response = $this->buckaroo->method('bancontactmrcash')->payEncrypted([
-            'invoice' => uniqid(),
-            'amountDebit' => 10.10,
-            'description' => 'Bancontact PayEncrypted Test 123',
+        $response = $this->buckaroo->method('bancontactmrcash')->payEncrypted($this->getBasePayPayload([],[
             'encryptedCardData' => '001SlXfd8MbiTd/JFwCiGVs3f6o4x6xt0aN29NzOSNZHPKlVsz/EWeQmyhb1gGZ86VY88DP7gf
             DV+UyjcPfpVfHZd7u+WkO71hnV2QfYILCBNqE1aiPv2GQVGdaGbuoQloKu1o3o3I1UDmVxivXTMQX76ovot89geA6hqbtakmpm
             vxeiwwea3l4htNoX1IlD1hfYkDDl9rzSu5ypcjvVs6aRGXK5iMHnyrmEsEnfdj/Q5XWbsD5xAm4u3y6J8d4UP7LB31VLECzZUT
             iJOtKKcCQlT01YThIkQlj8PWBBMtt4H52VN3IH2+wPYtR8HiOZzcA2HA7UxozogIpS53tIURj/g==',
-        ]);
+        ]));
 
         $this->assertTrue($response->isPendingProcessing());
     }
@@ -78,13 +71,12 @@ class BancontactTest extends BuckarooTestCase
      */
     public function it_creates_a_bancontact_recurring_payment()
     {
-        $response = $this->buckaroo->method('bancontactmrcash')->payRecurring([
-            'invoice' => 'testinvoice 123',
-            'amountDebit' => 10.50,
-            'originalTransactionKey' => '91D08EC01F414926A4CA29C059XXXXXX',
-        ]);
+        $response = $this->buckaroo->method('bancontactmrcash')->payRecurring($this->getBasePayPayload([], [
+            'originalTransactionKey' => '77FDD0E0CF9C4AF1B85CEA2942DE27DC',
+            'order' => '',
+        ]));
 
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isSuccess());
     }
 
     /**
@@ -93,13 +85,12 @@ class BancontactTest extends BuckarooTestCase
      */
     public function it_creates_a_bancontact_pay_one_click_payment()
     {
-        $response = $this->buckaroo->method('bancontactmrcash')->payOneClick([
-            'invoice' => 'testinvoice 123',
-            'amountDebit' => 10.50,
-            'originalTransactionKey' => '91D08EC01F414926A4CA29C059XXXXXX',
-        ]);
+        $response = $this->buckaroo->method('bancontactmrcash')->payOneClick($this->getBasePayPayload([],[
+            'originalTransactionKey' => '77FDD0E0CF9C4AF1B85CEA2942DE27DC',
+            'order' => '',
+        ]));
 
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isSuccess());
     }
 
     /**
@@ -108,12 +99,11 @@ class BancontactTest extends BuckarooTestCase
      */
     public function it_creates_a_bancontact_authorize()
     {
-        $response = $this->buckaroo->method('bancontactmrcash')->authorize([
-            'invoice' => 'Bancontact Authenticate SaveToken',
-            'description' => 'Bancontact Authenticate SaveToken',
-            'amountDebit' => 0.02,
+        $response = $this->buckaroo->method('bancontactmrcash')->authorize($this->getBasePayPayload([], [
             'savetoken' => false,
-        ]);
+        ]));
+
+        self::$authorizeTransactionKey = $response->getTransactionKey();
 
         $this->assertTrue($response->isWaitingOnUserInput());
     }
@@ -122,30 +112,37 @@ class BancontactTest extends BuckarooTestCase
      * @return void
      * @test
      */
-    public function it_creates_a_bancontact_capture()
-    {
-        $response = $this->buckaroo->method('bancontactmrcash')->capture([
-            'invoice' => 'Bancontact Authenticate SaveToken',
-            'description' => 'Bancontact Authenticate SaveToken',
-            'originalTransactionKey'    => 'D3EEF5279D9047A0B202334D8050B6CF',
-            'amountDebit' => 0.02,
-        ]);
-
-        $this->assertTrue($response->isWaitingOnUserInput());
-    }
-
-    /**
-     * @return void
-     * @test
-     */
+    // Replace the transaction key with the key from a successful authorization
     public function it_creates_a_bancontact_cancel_authorize()
     {
-        $response = $this->buckaroo->method('bancontactmrcash')->cancelAuthorize([
-            'invoice'                   => 'Bancontact Authenticate SaveToken',
-            'description'               => 'Bancontact Authenticate SaveToken',
-            'originalTransactionKey'    => '122862F217D44C4DAF4012D93301E168',
-        ]);
+        $response = $this->buckaroo->method('bancontactmrcash')->cancelAuthorize($this->getRefundPayload([
+            'originalTransactionKey' => self::$authorizeTransactionKey,
+            'amountCredit' => 100.30,
+            'amount' => 100.30,
+            'creditAmount' => 100.30,
 
-        $this->assertTrue($response->isValidationFailure());
+        ]));
+
+        $this->assertTrue($response->isSuccess());
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    // Replace the transaction key with the key from a successful authorization
+    public function it_creates_a_bancontact_capture()
+    {
+        $response = $this->buckaroo->method('bancontactmrcash')->authorize($this->getBasePayPayload([], [
+            'savetoken' => false,
+        ]));
+
+        self::$authorizeTransactionKey = $response->getTransactionKey();
+
+        $response = $this->buckaroo->method('bancontactmrcash')->capture($this->getBasePayPayload([], [
+            'originalTransactionKey' => self::$authorizeTransactionKey,
+        ]));
+
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/BatchTest.php
+++ b/tests/Buckaroo/Payments/BatchTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Buckaroo\Payments;
 
-use Buckaroo\Resources\Constants\Gender;
 use Tests\Buckaroo\BuckarooTestCase;
 
 /**
@@ -18,55 +17,10 @@ class BatchTest extends BuckarooTestCase
     {
         $transactions = array();
 
-        for($i=0;$i<3;$i++)
-        {
-            $invoice = $this->buckaroo->method('credit_management')->manually()->createCombinedInvoice([
-                'invoice' => rand(1000, 9999),
-                'applyStartRecurrent' => 'False',
-                'invoiceAmount' => 10.00,
-                'invoiceAmountVAT' => 1.00,
-                'invoiceDate' => date('Y-m-d'),
-                'dueDate' => date('Y-m-d'),
-                'schemeKey' => '2amq34',
-                'maxStepIndex' => 1,
-                'allowedServices' => 'ideal,mastercard',
-                'debtor' => [
-                    'code' => 'johnsmith4',
-                ],
-                'email' => 'youremail@example.nl',
-                'phone' => [
-                    'mobile' => '06198765432',
-                ],
-                'person' => [
-                    'culture' => 'nl-NL',
-                    'title' => 'Msc',
-                    'initials' => 'JS',
-                    'firstName' => 'Test',
-                    'lastNamePrefix' => 'Jones',
-                    'lastName' => 'Aflever',
-                    'gender' => Gender::MALE,
-                ],
-                'company' => [
-                    'culture' => 'nl-NL',
-                    'name' => 'My Company Corporation',
-                    'vatApplicable' => true,
-                    'vatNumber' => 'NL140619562B01',
-                    'chamberOfCommerce' => '20091741',
-                ],
-                'address' => [
-                    'street' => 'Hoofdtraat',
-                    'houseNumber' => '90',
-                    'houseNumberSuffix' => 'A',
-                    'zipcode' => '8441ER',
-                    'city' => 'Heerenveen',
-                    'state' => 'Friesland',
-                    'country' => 'NL',
-                ],
-            ]);
+        for ($i = 0; $i < 3; $i++) {
+            $invoice = $this->buckaroo->method('credit_management')->manually()->createCombinedInvoice($this->getInvoicePayload(['invoice' => uniqid()]));
 
-            $transactions[]  = $this->buckaroo->method('sepadirectdebit')->combine($invoice)->manually()->pay([
-                'invoice' => uniqid(),
-                'amountDebit' => 10.10,
+            $transactions[]  = $this->buckaroo->method('sepadirectdebit')->combine($invoice)->manually()->pay($this->getBasePayPayload([],[
                 'iban' => 'NL13TEST0123456789',
                 'bic' => 'TESTNL2A',
                 'collectdate' => date('Y-m-d'),
@@ -75,7 +29,7 @@ class BatchTest extends BuckarooTestCase
                 'customer' => [
                     'name' => 'John Smith',
                 ],
-            ]);
+            ]));
         }
 
         $response = $this->buckaroo->batch($transactions)->execute();

--- a/tests/Buckaroo/Payments/BelfiusTest.php
+++ b/tests/Buckaroo/Payments/BelfiusTest.php
@@ -30,10 +30,7 @@ class BelfiusTest extends BuckarooTestCase
      */
     public function it_creates_a_belfius_payment()
     {
-        $response = $this->buckaroo->method('belfius')->pay([
-            'amountDebit' => 10.10,
-            'invoice' => uniqid(),
-        ]);
+        $response = $this->buckaroo->method('belfius')->pay($this->getBasePayPayload());
 
         $this->assertTrue($response->isPendingProcessing());
     }
@@ -43,12 +40,12 @@ class BelfiusTest extends BuckarooTestCase
      */
     public function it_creates_a_belfius_refund()
     {
-        $response = $this->buckaroo->method('belfius')->refund([
-            'amountCredit' => 10,
-            'invoice' => '10000480',
-            'originalTransactionKey' => '0EF39AA94BD64FF38F1540DEB6XXXXXX',
-        ]);
+        $response = $this->buckaroo->method('belfius')->refund(
+            $this->getRefundPayload([
+                'originalTransactionKey' => '11FCBD00A4D8454DA4AFD1EF8F8046F0',
+            ])
+        );
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/BillinkTest.php
+++ b/tests/Buckaroo/Payments/BillinkTest.php
@@ -29,7 +29,14 @@ class BillinkTest extends BuckarooTestCase
      */
     public function it_creates_a_billink_payment()
     {
-        $response = $this->buckaroo->method('billink')->pay($this->getPaymentPayload());
+        $response = $this->buckaroo->method('billink')->pay($this->getPayPayload([
+            'trackAndTrace' => 'TR0F123456789',
+            'vatNumber' => '2',
+            'articles' => $this->getArticlesPayload(),
+        ]));
+
+        self::$payTransactionKey = $response->getTransactionKey();
+
 
         $this->assertTrue($response->isSuccess());
     }
@@ -39,7 +46,59 @@ class BillinkTest extends BuckarooTestCase
      */
     public function it_creates_a_billink_authorize()
     {
-        $response = $this->buckaroo->method('billink')->authorize($this->getPaymentPayload());
+        $response = $this->buckaroo->method('billink')->authorize($this->getPayPayload(
+            [
+                'trackAndTrace' => 'TR0F123456789',
+                'vatNumber' => '2',
+                'articles' => $this->getArticlesPayload(),
+            ]
+        ));
+
+        self::$authorizeTransactionKey = $response->getTransactionKey();
+
+        $this->assertTrue($response->isSuccess());
+    }
+    
+
+    // Not able to test (issue with amount) - Validation failure
+    // /**
+    //  * @test
+    //  */
+    // public function it_creates_a_billink_cancel_authorize()
+    // {
+    //     $response = $this->buckaroo->method('billink')->cancelAuthorize($this->getRefundPayload([
+    //         'originalTransactionKey' => self::$authorizeTransactionKey,
+    //         'amountCredit' => 100.30,
+    //     ]));
+
+
+    //     $this->assertTrue($response->isSuccess());
+    // }
+
+    /**
+     * @test
+     */
+    public function it_creates_a_billink_capture()
+    {
+        $response = $this->buckaroo->method('billink')->authorize($this->getPayPayload(
+            [
+                'trackAndTrace' => '12345678',
+                'vatNumber' => '2',
+                'articles' => $this->getArticlesPayload(),
+            ]
+        ));
+
+        $this->assertTrue($response->isSuccess());
+
+        sleep(2);
+        $response = $this->buckaroo->method('billink')->capture($this->getPayPayload(
+                [
+                    'originalTransactionKey' => $response->getTransactionKey(),
+                    'trackAndTrace' => '12345678',
+                    'vatNumber' => '2',
+                    'articles' => $this->getArticlesPayload(),
+                ]
+            ));
 
         $this->assertTrue($response->isSuccess());
     }
@@ -47,135 +106,12 @@ class BillinkTest extends BuckarooTestCase
     /**
      * @test
      */
-    public function it_creates_a_billink_capture()
-    {
-        $response = $this->buckaroo->method('billink')->capture([
-            'originalTransactionKey' => '74AD098CCFAA4F739FE16279B5059B6B',
-            //Set transaction key of the transaction to capture
-            'invoice' => '62905fa2650f4', //Set invoice id
-            'amountDebit' => 50.30, //set amount to capture
-            'articles' => [
-                [
-                    'identifier' => 'Articlenumber1',
-                    'description' => 'Blue Toy Car',
-                    'vatPercentage' => '21',
-                    'quantity' => '2',
-                    'price' => '20.10',
-                    'priceExcl' => 5,
-                ],
-                [
-                    'identifier' => 'Articlenumber2',
-                    'description' => 'Red Toy Car',
-                    'vatPercentage' => '21',
-                    'quantity' => '1',
-                    'price' => 10.10,
-                    'priceExcl' => 5,
-                ],
-            ],
-        ]);
-
-        $this->assertTrue($response->isFailed());
-    }
-
-    /**
-     * @test
-     */
     public function it_creates_a_billink_refund()
     {
-        $response = $this->buckaroo->method('billink')->refund([
-            'amountCredit' => 10,
-            'invoice' => 'testinvoice 123',
-            'originalTransactionKey' => '4E8BD922192746C3918BF4077CXXXXXX',
-        ]);
+        $response = $this->buckaroo->method('billink')->refund($this->getRefundPayload([
+            'originalTransactionKey' => self::$payTransactionKey,
+        ]));
 
-        $this->assertTrue($response->isFailed());
-    }
-
-    private function getPaymentPayload(): array
-    {
-        return [
-            'amountDebit' => 50.30,
-            'order' => uniqid(),
-            'invoice' => uniqid(),
-            'trackAndTrace' => 'TR0F123456789',
-            'vATNumber' => '2',
-            'billing' => [
-                'recipient' => [
-                    'category' => 'B2B',
-                    'careOf' => 'John Smith',
-                    'title' => 'Female',
-                    'initials' => 'JD',
-                    'firstName' => 'John',
-                    'lastName' => 'Do',
-                    'birthDate' => '01-01-1990',
-                    'chamberOfCommerce' => 'TEST',
-                ],
-                'address' => [
-                    'street' => 'Hoofdstraat',
-                    'houseNumber' => '13',
-                    'houseNumberAdditional' => 'a',
-                    'zipcode' => '1234AB',
-                    'city' => 'Heerenveen',
-                    'country' => 'NL',
-                ],
-                'phone' => [
-                    'mobile' => '0698765433',
-                    'landline' => '0109876543',
-                ],
-                'email' => 'test@buckaroo.nl',
-            ],
-            'shipping' => [
-                'recipient' => [
-                    'category' => 'B2C',
-                    'careOf' => 'John Smith',
-                    'title' => 'Male',
-                    'initials' => 'JD',
-                    'firstName' => 'John',
-                    'lastName' => 'Do',
-                    'birthDate' => '1990-01-01',
-                ],
-                'address' => [
-                    'street' => 'Kalverstraat',
-                    'houseNumber' => '13',
-                    'houseNumberAdditional' => 'b',
-                    'zipcode' => '4321EB',
-                    'city' => 'Amsterdam',
-                    'country' => 'NL',
-                ],
-            ],
-            'articles' => [
-                [
-                    'identifier' => 'Articlenumber1',
-                    'description' => 'Blue Toy Car',
-                    'vatPercentage' => '21',
-                    'quantity' => '2',
-                    'price' => '20.10',
-                    'priceExcl' => 5,
-                ],
-                [
-                    'identifier' => 'Articlenumber2',
-                    'description' => 'Red Toy Car',
-                    'vatPercentage' => '21',
-                    'quantity' => '1',
-                    'price' => 10.10,
-                    'priceExcl' => 5,
-                ],
-            ],
-        ];
-    }
-
-    /**
-     * @test
-     */
-    public function it_creates_a_billink_cancel_authorize()
-    {
-        $response = $this->buckaroo->method('billink')->cancelAuthorize([
-            'originalTransactionKey' => '74AD098CCFAA4F739FE16279B5059B6B',
-            //Set transaction key of the transaction to capture
-            'invoice' => '62905fa2650f4', //Set invoice id
-            'AmountCredit' => 10, //set amount to capture
-        ]);
-
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/BlikTest.php
+++ b/tests/Buckaroo/Payments/BlikTest.php
@@ -29,14 +29,26 @@ class BlikTest extends BuckarooTestCase
      */
     public function it_creates_a_blik_payment()
     {
-        $response = $this->buckaroo->method('blik')->pay([
-            'currency'      => 'PLN',
-            'amountDebit'   => 10.00,
-            'invoice'       => 'Blik Test Plugins Example',
-            'description'   => 'Blik Test Plugins Example',
+        $response = $this->buckaroo->method('blik')->pay($this->getBasePayPayload([], [
+            'currency' => 'PLN',
             'email'         => 'test@buckar00.nl'
-        ]);
+        ]));
 
         $this->assertTrue($response->isPendingProcessing());
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_a_blik_refund()
+    {
+        $response = $this->buckaroo->method('blik')->refund(
+            $this->getRefundPayload([
+                'originalTransactionKey' => 'C3B303C9DEA4401BA6732055030C2BD8',
+                'currency' => 'PLN'
+            ])
+        );
+
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/BuckarooVoucherTest.php
+++ b/tests/Buckaroo/Payments/BuckarooVoucherTest.php
@@ -24,6 +24,7 @@ use Tests\Buckaroo\BuckarooTestCase;
 
 class BuckarooVoucherTest extends BuckarooTestCase
 {
+    private static ?string $voucherCode = null;
     /**
      * @return void
      * @test
@@ -33,9 +34,72 @@ class BuckarooVoucherTest extends BuckarooTestCase
         $response = $this->buckaroo->method('buckaroovoucher')->create(
             [
                 'usageType' => '2',
-                'validFrom' => '2022-01-01',
-                'validUntil' => '2024-01-01',
-                'creationBalance' => '5',
+                'validFrom' => '2025-01-01',
+                'validUntil' => '2030-01-01',
+                'creationBalance' => '10',
+            ]
+        );
+
+        $this->assertTrue($response->isSuccess());
+
+        self::$voucherCode = $response->getServiceParameters()['vouchercode'];
+    }
+
+    /**
+     * @return void
+     * @test
+     * @depends it_creates_a_buckaroo_voucher
+     */
+    public function it_creates_a_buckaroo_payment()
+    {
+        $response = $this->buckaroo->method('buckaroovoucher')->pay($this->getPayPayload([
+            'vouchercode' => self::$voucherCode,
+            'amountDebit' => 5,
+        ]));
+
+        $this->assertTrue($response->isSuccess());
+
+        self::$payTransactionKey = $response->getTransactionKey();
+    }
+
+    /**
+     * @return void
+     * @test
+     * @depends it_creates_a_buckaroo_voucher
+     */
+    public function it_creates_a_buckaroo_pay_remainder()
+    {
+        $giftCardResponse = $this->buckaroo->method('giftcard')->pay($this->getBasePayPayload([], [
+            'amountDebit' => 10,
+            'name' => 'boekenbon',
+            'intersolveCardnumber' => '0000000000000000001',
+            'intersolvePIN' => '500',
+        ]));
+
+        $this->assertTrue($giftCardResponse->isSuccess());
+
+        $response = $this->buckaroo->method('buckaroovoucher')->payRemainder($this->getBasePayPayload([], [
+            'originalTransactionKey' => $giftCardResponse->data('RelatedTransactions')[0]['RelatedTransactionKey'],
+            'amountDebit' => 9.50,
+            'invoice' => uniqid(),
+            'vouchercode' => self::$voucherCode,
+        ]));
+
+        $this->assertTrue($response->isSuccess());
+    }
+
+    /**
+     * @return void
+     * @test
+     * @depends it_creates_a_buckaroo_payment
+     */
+    public function it_creates_a_buckaroo_refund()
+    {
+        $response = $this->buckaroo->method('buckaroovoucher')->refund(
+            [
+                'amountCredit' => 5,
+                'invoice' => uniqid(),
+                'originalTransactionKey' => self::$payTransactionKey,
             ]
         );
 
@@ -45,82 +109,32 @@ class BuckarooVoucherTest extends BuckarooTestCase
     /**
      * @return void
      * @test
-     */
-    public function it_creates_a_buckaroo_payment()
-    {
-        $response = $this->buckaroo->method('buckaroovoucher')->pay(
-            [
-                'amountDebit' => '10',
-                'invoice' => uniqid(),
-                'vouchercode' => 'vouchercode',
-            ]
-        );
-
-        $this->assertTrue($response->isFailed());
-    }
-
-    /**
-     * @return void
-     * @test
-     */
-    public function it_creates_a_buckaroo_pay_remainder()
-    {
-        $response = $this->buckaroo->method('buckaroovoucher')->payRemainder(
-            [
-                'amountDebit' => '10',
-                'invoice' => uniqid(),
-                'vouchercode' => 'vouchercode',
-                'originalTransaction' => '4E8BD922192746C3918BF4077CXXXXXX',
-            ]
-        );
-
-        $this->assertTrue($response->isFailed());
-    }
-
-    /**
-     * @return void
-     * @test
-     */
-    public function it_creates_a_buckaroo_refund()
-    {
-        $response = $this->buckaroo->method('buckaroovoucher')->refund(
-            [
-                'amountCredit' => 10,
-                'invoice' => uniqid(),
-                'originalTransactionKey' => '4E8BD922192746C3918BF4077CXXXXXX',
-            ]
-        );
-
-        $this->assertTrue($response->isFailed());
-    }
-
-    /**
-     * @return void
-     * @test
+     * @depends it_creates_a_buckaroo_voucher
      */
     public function it_creates_a_buckaroo_get_balance()
     {
         $response = $this->buckaroo->method('buckaroovoucher')->getBalance(
             [
-                'vouchercode' => 'vouchercode',
+                'vouchercode' => self::$voucherCode,
             ]
         );
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 
     /**
      * @return void
      * @test
+     * @depends it_creates_a_buckaroo_voucher
      */
     public function it_deactivate_a_buckaroo_voucher()
     {
         $response = $this->buckaroo->method('buckaroovoucher')->deactivate(
             [
-                'vouchercode' => 'vouchercode',
+                'vouchercode' => self::$voucherCode,
             ]
         );
-        
-        $this->assertTrue($response->isFailed());
+
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/ClickToPayTest.php
+++ b/tests/Buckaroo/Payments/ClickToPayTest.php
@@ -30,13 +30,10 @@ class ClickToPayTest extends BuckarooTestCase
      */
     public function it_creates_a_click_to_pay_payment()
     {
-        $response = $this->buckaroo->method('clicktopay')->pay(
-            [
-                'amountDebit' => 0.01,
-                'invoice' => uniqid(),
-                'continueOnIncomplete' => "1",
-            ]
-        );
+        $response = $this->buckaroo->method('clicktopay')->pay($this->getBasePayPayload([], [
+            'amountDebit' => 0.01,
+            'continueOnIncomplete' => "1",
+        ]));
 
         $this->assertTrue($response->isWaitingOnUserInput());
     }

--- a/tests/Buckaroo/Payments/CreditcardTest.php
+++ b/tests/Buckaroo/Payments/CreditcardTest.php
@@ -30,11 +30,9 @@ class CreditcardTest extends BuckarooTestCase
      */
     public function it_creates_a_creditcard_payment()
     {
-        $response = $this->buckaroo->method('creditcard')->pay([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
+        $response = $this->buckaroo->method('creditcard')->pay($this->getBasePayPayload([],[
             'name' => 'visa',
-        ]);
+        ]));
 
         $this->assertTrue($response->isWaitingOnUserInput());
     }
@@ -45,15 +43,12 @@ class CreditcardTest extends BuckarooTestCase
      */
     public function it_creates_a_creditcard_encrypted_payment()
     {
-        $response = $this->buckaroo->method('creditcard')->payEncrypted([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
+        $response = $this->buckaroo->method('creditcard')->payEncrypted($this->getBasePayPayload([],[
             'name' => 'mastercard',
-            'encryptedCardData' => '001u8gJNwngKubFCO6FmJod6aESlIFATkKYaj47KlgBp7f3NeVxUzChg1Aug7WD2vc5wut2KU
-            9NPLUaO0tFmzhVLZoDWn7dX4AzGxSjPrsPmDMWYcEkIwMZfcyJqoRfFkF3j15mil3muXxhR1a609NfkTo11J3ENVsvU3k60z',
-        ]);
+            'encryptedCardData' => '001u8gJNwngKubFCO6FmJod6aESlIFATkKYaj47KlgBp7f3NeVxUzChg1Aug7WD2vc5wut2KU9NPLUaO0tFmzhVLZoDWn7dX4AzGxSjPrsPmDMWYcEkIwMZfcyJqoRfFkF3j15mil3muXxhR1a609NfkTo11J3ENVsvU3k60z+x0jCw6NjzbrweVQhBRkrbs7TBJkS4tR38JiDsXyH2E1JmRHE+o2P9qz4at6w3zggmwImvjt5IIjEr6g8KfsIDXfv7YjEzhJ3P+7uuGoyG2WYm/Pr0+iEmTj5Q/ijkxu1+cDqv5eiB+80KgffPItUZDrnv9sKlVBAr+f53nm1G+Sxp0Q==',
+        ]));
 
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isPendingProcessing());
     }
 
     /**
@@ -62,16 +57,13 @@ class CreditcardTest extends BuckarooTestCase
      */
     public function it_creates_a_creditcard_security_code_payment()
     {
-        $response = $this->buckaroo->method('creditcard')->payWithSecurityCode([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
-            'originalTransactionKey' => '6C5DBB69E74644958F8C25199514DC6C',
+        $response = $this->buckaroo->method('creditcard')->payWithSecurityCode($this->getBasePayPayload([],[
+            'originalTransactionKey' => '4D81D54DAA77407689208A7609795B8F',
             'name' => 'mastercard',
-            'encryptedSecurityCode' => '001u8gJNwngKubFCO6FmJod6aESlIFATkKYaj47KlgBp7f3NeVxUzChg1Aug7WD2vc5wut2
-            KU9NPLUaO0tFmzhVLZoDWn7dX4AzGxSjPrsPmDMWYcEkIwMZfcyJqoRfFkF3j15mil3muXxhR1a609NfkTo11J3ENVsvU3k60z',
-        ]);
+            'encryptedSecurityCode' => '001F3AJT7wkJa04zE8c78P7spOAgHSKH1YKgPlOwXhW049VfIXMwZO32RYna9xZRyUCtfODIoCL8GRQoaZbStlBT4rbF5e4PPvWFSKdvua4rq+GQDNAghfa+ZQz0BzBPfjS0WBdFape9n3zH2vC/0m+wI3QZiDpYYgyWC1/Y3udJDU7JRTVMq/BDHGet+IZ2CDnkeGl813kkYymzYon/QeuQRQ0Wsec5bmVQNYGx62fz70/vLgs0ffff+6DtZtnZWfByRkTwMNebJotlOsSkbhVR5FrHpAbNPCJI+LvJcJL7Eoo+ZuX5/LWGmsT6qnR/uLiIw1DI7mTKGy6/P7IljAE+g==',
+        ]));
 
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isPendingProcessing());
     }
 
     /**
@@ -80,14 +72,12 @@ class CreditcardTest extends BuckarooTestCase
      */
     public function it_creates_a_creditcard_refund()
     {
-        $response = $this->buckaroo->method('creditcard')->refund([
-            'amountCredit' => 10,
-            'invoice' => 'testinvoice 123',
-            'originalTransactionKey' => '13FAF43579D94F5FB8119A6819XXXXXX',
+        $response = $this->buckaroo->method('creditcard')->refund($this->getRefundPayload([
+            'originalTransactionKey' => '3D40E227D336441689092DDFC388810B',
             'name' => 'mastercard',
-        ]);
+        ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 
     /**
@@ -96,11 +86,9 @@ class CreditcardTest extends BuckarooTestCase
      */
     public function it_creates_a_creditcard_authorize()
     {
-        $response = $this->buckaroo->method('creditcard')->authorize([
-            'amountDebit' => 10,
-            'invoice' => 'testinvoice 123',
+        $response = $this->buckaroo->method('creditcard')->authorize($this->getBasePayPayload([],[
             'name' => 'mastercard',
-        ]);
+        ]));
 
         $this->assertTrue($response->isWaitingOnUserInput());
     }
@@ -111,33 +99,28 @@ class CreditcardTest extends BuckarooTestCase
      */
     public function it_creates_a_creditcard_encrypted_authorize()
     {
-        $response = $this->buckaroo->method('creditcard')->authorizeEncrypted([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
+        $response = $this->buckaroo->method('creditcard')->authorizeEncrypted($this->getBasePayPayload([],[
             'name' => 'mastercard',
-            'encryptedCardData' => '001u8gJNwngKubFCO6FmJod6aESlIFATkKYaj47KlgBp7f3NeVxUzChg1Aug7WD2vc5wut2KU
-            9NPLUaO0tFmzhVLZoDWn7dX4AzGxSjPrsPmDMWYcEkIwMZfcyJqoRfFkF3j15mil3muXxhR1a609NfkTo11J3ENVsvU3k60z',
-        ]);
+            'encryptedCardData' => '001u8gJNwngKubFCO6FmJod6aESlIFATkKYaj47KlgBp7f3NeVxUzChg1Aug7WD2vc5wut2KU9NPLUaO0tFmzhVLZoDWn7dX4AzGxSjPrsPmDMWYcEkIwMZfcyJqoRfFkF3j15mil3muXxhR1a609NfkTo11J3ENVsvU3k60z+x0jCw6NjzbrweVQhBRkrbs7TBJkS4tR38JiDsXyH2E1JmRHE+o2P9qz4at6w3zggmwImvjt5IIjEr6g8KfsIDXfv7YjEzhJ3P+7uuGoyG2WYm/Pr0+iEmTj5Q/ijkxu1+cDqv5eiB+80KgffPItUZDrnv9sKlVBAr+f53nm1G+Sxp0Q==',
+        ]));
 
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isPendingProcessing());
     }
 
+    // 492 - Technical failure
     /**
      * @return void
      * @test
      */
     public function it_creates_a_creditcard_security_code_authorize()
     {
-        $response = $this->buckaroo->method('creditcard')->authorizeWithSecurityCode([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
-            'originalTransactionKey' => '6C5DBB69E74644958F8C25199514DC6C',
+        $response = $this->buckaroo->method('creditcard')->authorizeWithSecurityCode($this->getBasePayPayload([],[
+            'originalTransactionKey' => '4D81D54DAA77407689208A7609795B8F',
             'name' => 'mastercard',
-            'encryptedSecurityCode' => '001u8gJNwngKubFCO6FmJod6aESlIFATkKYaj47KlgBp7f3NeVxUzChg1Aug7WD2vc5wut2KU
-            9NPLUaO0tFmzhVLZoDWn7dX4AzGxSjPrsPmDMWYcEkIwMZfcyJqoRfFkF3j15mil3muXxhR1a609NfkTo11J3ENVsvU3k60z',
-        ]);
+            'encryptedSecurityCode' => '001F3AJT7wkJa04zE8c78P7spOAgHSKH1YKgPlOwXhW049VfIXMwZO32RYna9xZRyUCtfODIoCL8GRQoaZbStlBT4rbF5e4PPvWFSKdvua4rq+GQDNAghfa+ZQz0BzBPfjS0WBdFape9n3zH2vC/0m+wI3QZiDpYYgyWC1/Y3udJDU7JRTVMq/BDHGet+IZ2CDnkeGl813kkYymzYon/QeuQRQ0Wsec5bmVQNYGx62fz70/vLgs0ffff+6DtZtnZWfByRkTwMNebJotlOsSkbhVR5FrHpAbNPCJI+LvJcJL7Eoo+ZuX5/LWGmsT6qnR/uLiIw1DI7mTKGy6/P7IljAE+g==',
+        ]));
 
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isPendingProcessing());
     }
 
     /**
@@ -146,28 +129,10 @@ class CreditcardTest extends BuckarooTestCase
      */
     public function it_creates_a_creditcard_capture()
     {
-        $response = $this->buckaroo->method('creditcard')->capture([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
-            'originalTransactionKey' => '6C5DBB69E74644958F8C25199514DC6C',
+        $response = $this->buckaroo->method('creditcard')->capture($this->getBasePayPayload([],[
+            'originalTransactionKey' => '78ADA073DAD74E14BFC83EE308B70374',
             'name' => 'mastercard',
-        ]);
-
-        $this->assertTrue($response->isFailed());
-    }
-
-    /**
-     * @return void
-     * @test
-     */
-    public function it_creates_a_creditcard_pay_recurrent()
-    {
-        $response = $this->buckaroo->method('creditcard')->payRecurrent([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
-            'originalTransactionKey' => '6C5DBB69E74644958F8C25199514DC6C',
-            'name' => 'mastercard',
-        ]);
+        ]));
 
         $this->assertTrue($response->isSuccess());
     }
@@ -176,16 +141,29 @@ class CreditcardTest extends BuckarooTestCase
      * @return void
      * @test
      */
+    public function it_creates_a_creditcard_pay_recurrent()
+    {
+        $response = $this->buckaroo->method('creditcard')->payRecurrent($this->getBasePayPayload([],[
+            'originalTransactionKey' => '6C5DBB69E74644958F8C25199514DC6C',
+            'name' => 'mastercard',
+        ]));
+
+        $this->assertTrue($response->isSuccess());
+    }
+
+    // 491 - Validation failure (no info)
+    /**
+     * @return void
+     * @test
+     */
     public function it_creates_a_creditcard_cancel_authorize()
     {
-        $response = $this->buckaroo->method('creditcard')->cancelAuthorize([
+        $response = $this->buckaroo->method('creditcard')->cancelAuthorize($this->getBasePayPayload([],[
+            'originalTransactionKey' => '41733E4210684988939CEE58AC899602',
             'name' => 'mastercard',
-            'amountCredit' => 10,
-            'originalTransactionKey' => 'F86579ECED1D493887ECAE7C287BXXXX',
-            'invoice' => 'testinvoice12345cvx',
-        ]);
+        ]));
 
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isPendingProcessing());
     }
 
     /**
@@ -194,12 +172,10 @@ class CreditcardTest extends BuckarooTestCase
      */
     public function it_creates_a_creditcard_token_authorize()
     {
-        $response = $this->buckaroo->method('creditcard')->authorizeWithToken([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
+        $response = $this->buckaroo->method('creditcard')->authorizeWithToken($this->getBasePayPayload([],[
             'name' => 'visa',
-            'sessionId' => 'hf_23sASKvHadWu0ZZj',
-        ]);
+            'sessionId' => 'hf_43ab37u53XIDOpJg',
+        ]));
 
         $this->assertTrue($response->isPendingProcessing());
     }
@@ -211,12 +187,10 @@ class CreditcardTest extends BuckarooTestCase
      */
     public function it_creates_a_creditcard_hosted_fields_payment()
     {
-        $response = $this->buckaroo->method('creditcard')->payWithToken([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
+        $response = $this->buckaroo->method('creditcard')->payWithToken($this->getBasePayPayload([],[
             'name' => 'visa',
-            'sessionId' => 'hf_23sASKvHadWu0ZZj',
-        ]);
+            'sessionId' => 'hf_43ab37u53XIDOpJg',
+        ]));
 
         $this->assertTrue($response->isPendingProcessing());
     }

--- a/tests/Buckaroo/Payments/EPSTest.php
+++ b/tests/Buckaroo/Payments/EPSTest.php
@@ -30,12 +30,11 @@ class EPSTest extends BuckarooTestCase
      */
     public function it_creates_a_eps_payment()
     {
-        $response = $this->buckaroo->method('eps')->pay([
-            'invoice' => uniqid(),
-            'amountDebit' => 10.10,
-        ]);
+        $response = $this->buckaroo->method('eps')->pay($this->getBasePayPayload());
 
         $this->assertTrue($response->isSuccess());
+
+        self::$payTransactionKey = $response->getTransactionKey();
     }
 
     /**
@@ -43,13 +42,12 @@ class EPSTest extends BuckarooTestCase
      */
     public function it_creates_a_eps_refund()
     {
-        $response = $this->buckaroo->method('eps')->refund([
-            'amountCredit' => 10,
-            'invoice' => 'testinvoice 123',
-            'description' => 'refund',
-            'originalTransactionKey' => '2D04704995B74D679AACC59F87XXXXXX',
-        ]);
+        $response = $this->buckaroo->method('eps')->refund(
+            $this->getRefundPayload([
+                'originalTransactionKey' => self::$payTransactionKey,
+            ])
+        );
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/EmandatesTest.php
+++ b/tests/Buckaroo/Payments/EmandatesTest.php
@@ -48,7 +48,7 @@ class EmandatesTest extends BuckarooTestCase
             'debtorbankid' => 'INGBNL2A',
             'debtorreference' => 'klant1234',
             'language' => 'nl',
-            'mandateid' => '1DC1234567890',
+            'mandateid' => '1DC' . strtoupper(uniqid(mt_rand())),
         ]);
 
         $this->assertTrue($response->isPendingProcessing());
@@ -64,7 +64,7 @@ class EmandatesTest extends BuckarooTestCase
             'mandateid' => '1DC1234567890',
         ]);
 
-        $this->assertTrue($response->isPendingProcessing());
+        $this->assertTrue($response->isSuccess());
     }
 
     /**
@@ -78,9 +78,10 @@ class EmandatesTest extends BuckarooTestCase
             'debtorbankid' => 'ABNANL2A',
         ]);
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isPendingProcessing());
     }
 
+    //todo: "Unknown action 'CancelMandate' used on service 'emandate'."
     /**
      * @return void
      * @test
@@ -88,11 +89,11 @@ class EmandatesTest extends BuckarooTestCase
     public function it_cancels_mandante_on_emandates()
     {
         $response = $this->buckaroo->method('emandates')->cancelMandate([
-            'mandateid' => '1DC1234567890',
+            'mandateid' => '1DC169627947667DC2DB3C7DEA',
             'emandatereason' => 'testing cancel',
-            'purchaseid' => 'purchaseid1234',
+            'purchaseid' => 'purchaseid 1234',
         ]);
 
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/ExternalPaymentTest.php
+++ b/tests/Buckaroo/Payments/ExternalPaymentTest.php
@@ -30,13 +30,13 @@ class ExternalPaymentTest extends BuckarooTestCase
      */
     public function it_creates_a_external_payment()
     {
-        $response = $this->buckaroo->method('externalPayment')->pay([
-            'invoice' => uniqid(),
-            'amountDebit' => 11.10,
+        $response = $this->buckaroo->method('externalPayment')->pay($this->getBasePayPayload([], [
             'channel' => 'BACKOFFICE'
-        ]);
+        ]));
 
         $this->assertTrue($response->isSuccess());
+
+        self::$payTransactionKey = $response->getTransactionKey();
     }
 
     /**
@@ -44,13 +44,13 @@ class ExternalPaymentTest extends BuckarooTestCase
      */
     public function it_creates_a_external_refund()
     {
-        $response = $this->buckaroo->method('externalPayment')->refund([
-            'amountCredit' => 10,
-            'invoice' => 'testinvoice 123',
-            'description' => 'refund',
-            'originalTransactionKey' => '2D04704995B74D679AACC59F87XXXXXX',
-        ]);
+        $response = $this->buckaroo->method('externalPayment')->refund(
+            $this->getRefundPayload([
+                'channel' => 'BACKOFFICE',
+                'originalTransactionKey' => self::$payTransactionKey,
+            ])
+        );
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/GiftcardsTest.php
+++ b/tests/Buckaroo/Payments/GiftcardsTest.php
@@ -29,15 +29,18 @@ class GiftcardsTest extends BuckarooTestCase
      */
     public function it_creates_a_giftcards_payment()
     {
-        $response = $this->buckaroo->method('giftcard')->pay([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
+        $response = $this->buckaroo->method('giftcard')->pay($this->getBasePayPayload([], [
+            'amountDebit' => 40.30,
             'name' => 'boekenbon',
             'intersolveCardnumber' => '0000000000000000001',
-            'intersolvePIN' => '1000',
-        ]);
+            'intersolvePIN' => '4030',
+            'email'         => 'test@buckar00.nl',
+            'lastName'         => 'Test'
+        ]));
 
         $this->assertTrue($response->isSuccess());
+
+        self::$payTransactionKey = $response->getTransactionKey();
     }
 
     /**
@@ -45,24 +48,29 @@ class GiftcardsTest extends BuckarooTestCase
      */
     public function it_creates_a_giftcards_partial_payment()
     {
-        $giftCardResponse = $this->buckaroo->method('giftcard')->pay([
+        $giftCardResponse = $this->buckaroo->method('giftcard')->pay($this->getBasePayPayload([], [
             'amountDebit' => 10,
-            'invoice' => uniqid(),
             'name' => 'boekenbon',
             'intersolveCardnumber' => '0000000000000000001',
-            'intersolvePIN' => '500',
-        ]);
+            'intersolvePIN' => '0500',
+            'email'         => 'test@buckar00.nl',
+            'lastName'         => 'Test'
+
+        ]));
 
         $this->assertTrue($giftCardResponse->isSuccess());
 
-        $response = $this->buckaroo->method('ideal')->payRemainder([
+        $response = $this->buckaroo->method('giftcard')->payRemainder($this->getBasePayPayload([], [
             'originalTransactionKey' => $giftCardResponse->data('RelatedTransactions')[0]['RelatedTransactionKey'],
-            'invoice' => $giftCardResponse->data('Invoice'),
-            'amountDebit' => 10.10,
-            'issuer' => 'ABNANL2A',
-        ]);
+            'amountDebit' => 5.00,
+            'name' => 'boekenbon',
+            'intersolveCardnumber' => '0000000000000000001',
+            'intersolvePIN' => '0500',
+            'email'         => 'test@buckar00.nl',
+            'lastName'         => 'Test'
+        ]));
 
-        $this->assertTrue($response->isPendingProcessing());
+        $this->assertTrue($response->isSuccess());
     }
 
     /**
@@ -70,15 +78,15 @@ class GiftcardsTest extends BuckarooTestCase
      */
     public function it_creates_a_giftcards_refund()
     {
-        $response = $this->buckaroo->method('giftcard')->refund([
-            'amountCredit' => 10,
-            'invoice' => 'testinvoice 123',
-            'originalTransactionKey' => '2D04704995B74D679AACC59F87XXXXXX',
-            'name' => 'boekenbon',
-            'email' => 'test123@hotmail.com',
-            'lastname' => 'test123'
-        ]);
+        $response = $this->buckaroo->method('giftcard')->refund(
+            $this->getRefundPayload([
+                'originalTransactionKey' => self::$payTransactionKey,
+                'name' => 'boekenbon',
+                'email'         => 'test@buckar00.nl',
+                'lastName'         => 'Test'
+            ])
+        );
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/IdealProcessingTest.php
+++ b/tests/Buckaroo/Payments/IdealProcessingTest.php
@@ -21,45 +21,9 @@
 namespace Tests\Buckaroo\Payments;
 
 use Tests\Buckaroo\BuckarooTestCase;
-use Buckaroo\Config\Config;
-
-
-class CustomConfig extends Config
-{
-    public function __construct()
-    {
-        $websiteKey = 'Set Key';
-        $secretKey = 'From other resources like DB/ENV/Platform Config';
-
-        parent::__construct($websiteKey, $secretKey);
-    }
-}
 
 class IdealProcessingTest extends BuckarooTestCase
 {
-    protected array $paymentPayload;
-    protected function setUp(): void
-    {
-        $this->paymentPayload = [
-            'invoice' => uniqid(),
-            'amountDebit' => 10.10,
-            'issuer' => 'ABNANL2A',
-            'pushURL' => 'https://buckaroo.dev/push',
-            'returnURL' => 'https://buckaroo.dev/return',
-            'clientIP' => [
-                'address' => '123.456.789.123',
-                'type' => 0,
-            ],
-            'customParameters' => [
-                'CustomerBillingFirstName' => 'test'
-            ],
-            'additionalParameters' => [
-                'initiated_by_magento' => 1,
-                'service_action' => 'something',
-            ],
-        ];
-    }
-
     /**
      * @return void
      * @test
@@ -81,9 +45,15 @@ class IdealProcessingTest extends BuckarooTestCase
      * @return void
      * @test
      */
-    public function it_creates_a_idealprocessing_payment()
+    public function it_creates_an_idealprocessing_payment()
     {
-        $response = $this->buckaroo->method('idealprocessing')->pay($this->paymentPayload);
+        $response = $this->buckaroo->method('idealprocessing')->pay($this->getBasePayPayload([],[
+            'pushURL' => 'https://buckaroo.dev/push',
+            'issuer' => 'ABNANL2A',
+            'customParameters' => [
+                'CustomerBillingFirstName' => 'Test'
+            ],
+        ]));
 
         $this->assertTrue($response->isPendingProcessing());
     }

--- a/tests/Buckaroo/Payments/IdealQRTest.php
+++ b/tests/Buckaroo/Payments/IdealQRTest.php
@@ -29,12 +29,7 @@ class IdealQRTest extends BuckarooTestCase
      */
     public function it_creates_a_ideal_qr()
     {
-        $response = $this->buckaroo->method('ideal_qr')->generate([
-            'description' => 'Test purchase',
-            'returnURL'         => 'https://buckaroo.dev/return',
-            'returnURLCancel'   => 'https://buckaroo.dev/cancel',
-            'returnURLError'    => 'https://buckaroo.dev/error',
-            'returnURLReject'   => 'https://buckaroo.dev/reject',
+        $response = $this->buckaroo->method('ideal_qr')->generate($this->getBasePayPayload(['invoice'],[
             'minAmount' => '0.10',
             'maxAmount' => '10.0',
             'imageSize' => '2000',
@@ -44,11 +39,7 @@ class IdealQRTest extends BuckarooTestCase
             'amountIsChangeable' => true,
             'expiration' => '2030-09-30',
             'isProcessing' => false,
-            'additionalParameters' => [
-                'initiated_by_magento' => '1',
-                'service_action' => 'something',
-            ]
-        ]);
+        ]));
 
         $this->assertTrue($response->isSuccess());
     }

--- a/tests/Buckaroo/Payments/In3OldTest.php
+++ b/tests/Buckaroo/Payments/In3OldTest.php
@@ -25,16 +25,17 @@ use Buckaroo\Resources\Constants\Gender;
 
 class In3OldTest extends BuckarooTestCase
 {
-    /**
-     * @return void
-     * @test
-     */
-    public function it_creates_a_in3old_payment()
-    {
-        $response = $this->buckaroo->method('in3old')->pay($this->getPaymentPayload());
+    // // 491 - Action Pay is no longer available for Capayable
+    // /**
+    //  * @return void
+    //  * @test
+    //  */
+    // public function it_creates_a_in3old_payment()
+    // {
+    //     $response = $this->buckaroo->method('in3old')->pay($this->getPaymentPayload());
 
-        $this->assertTrue($response->isSuccess());
-    }
+    //     $this->assertTrue($response->isSuccess());
+    // }
 
     /**
      * @return void
@@ -53,71 +54,60 @@ class In3OldTest extends BuckarooTestCase
      */
     public function it_creates_a_in3old_refund()
     {
-        $response = $this->buckaroo->method('in3Old')->refund([
-            'amountCredit' => 10,
-            'invoice' => '10000480',
-            'originalTransactionKey' => '9AA4C81A08A84FA7B68E6A6A6291XXXX',
-        ]);
+        $response = $this->buckaroo->method('in3Old')->refund($this->getRefundPayload([
+            'originalTransactionKey' => 'C1311F77EB3F48CDB5774F7C6842FE12',
+        ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 
     private function getPaymentPayload(): array
     {
-        return [
-            'amountDebit' => 9.5,
-            'order' => uniqid(),
-            'invoice' => uniqid(),
-            'description' => 'This is a test order',
-            'invoiceDate' => '22-01-2018',
-            'customerType' => 'Company',
-            'email' => 'test@buckaroo.nl',
-            'phone' => [
-                'mobile' => '0612345678',
-            ],
-            'articles' => [
-                [
-                    'identifier' => uniqid(),
-                    'description' => 'Blue Toy Car',
-                    'quantity' => '1',
-                    'price' => 10.00,
+        return $this->getPayPayload(
+            [
+                'invoiceDate' => '22-01-2018',
+                'customerType' => 'Company',
+                'articles' => $this->getArticlesPayload(['vatPercentage']),
+                'email' => 'test@buckaroo.nl',
+                'phone' => [
+                    'mobile' => '0612345678',
                 ],
-            ],
-            'company' => [
-                'companyName' => 'My Company B.V.',
-                'chamberOfCommerce' => '123456',
-            ],
-            'customer' => [
-                'gender' => Gender::FEMALE,
-                'initials' => 'J.S.',
-                'lastName' => 'Aflever',
-                'email' => 'billingcustomer@buckaroo.nl',
-                'phone' => '0610000000',
-                'culture' => 'nl-NL',
-                'birthDate' => '1990-01-01',
-            ],
-            'address' => [
-                'street' => 'Hoofdstraat',
-                'houseNumber' => '2',
-                'houseNumberAdditional' => 'a',
-                'zipcode' => '8441EE',
-                'city' => 'Heerenveen',
-                'country' => 'NL',
-            ],
-            'subtotals' => [
-                [
-                    'name' => 'Korting',
-                    'value' => -2.00,
+                'company' => [
+                    'companyName' => 'My Company B.V.',
+                    'chamberOfCommerce' => '123456',
                 ],
-                [
-                    'name' => 'Betaaltoeslag',
-                    'value' => 0.50,
+                'customer' => [
+                    'gender' => Gender::FEMALE,
+                    'initials' => 'J.S.',
+                    'lastName' => 'Aflever',
+                    'email' => 'billingcustomer@buckaroo.nl',
+                    'phone' => '0610000000',
+                    'culture' => 'nl-NL',
+                    'birthDate' => '1990-01-01',
                 ],
-                [
-                    'name' => 'Verzendkosten',
-                    'value' => 1.00,
+                'address' => [
+                    'street' => 'Hoofdstraat',
+                    'houseNumber' => '2',
+                    'houseNumberAdditional' => 'a',
+                    'zipcode' => '8441EE',
+                    'city' => 'Heerenveen',
+                    'country' => 'NL',
                 ],
-            ],
-        ];
+                'subtotals' => [
+                    [
+                        'name' => 'Korting',
+                        'value' => -2.00,
+                    ],
+                    [
+                        'name' => 'Betaaltoeslag',
+                        'value' => 0.50,
+                    ],
+                    [
+                        'name' => 'Verzendkosten',
+                        'value' => 1.00,
+                    ],
+                ],
+            ]
+        );
     }
 }

--- a/tests/Buckaroo/Payments/In3Test.php
+++ b/tests/Buckaroo/Payments/In3Test.php
@@ -32,7 +32,11 @@ class In3Test extends BuckarooTestCase
      */
     public function it_creates_a_in3_payment()
     {
-        $response = $this->buckaroo->method('in3')->pay($this->getPaymentPayload());
+        $response = $this->buckaroo->method('in3')->pay($this->getPayPayload([
+            'billing' => $this->getBillingPayload(['title', 'conversationLanguage', 'identificationNumber']),
+            'shipping' => $this->getShippingPayload(['title', 'conversationLanguage', 'identificationNumber']),
+            'articles' => $this->getArticlesPayload(),
+        ]));
 
         $this->assertTrue($response->isPendingProcessing());
     }
@@ -43,102 +47,10 @@ class In3Test extends BuckarooTestCase
      */
     public function it_creates_a_in3_refund()
     {
-        $response = $this->buckaroo->method('in3Old')->refund([
-            'amountCredit' => 10,
-            'invoice' => '10000480',
-            'originalTransactionKey' => '9AA4C81A08A84FA7B68E6A6A6291XXXX',
-        ]);
+        $response = $this->buckaroo->method('in3')->refund($this->getRefundPayload([
+            'originalTransactionKey' => 'B535EC6AC624431ABA27D849F44700BA',
+        ]));
 
-        $this->assertTrue($response->isFailed());
-    }
-
-    private function getPaymentPayload(?array $additional = null): array
-    {
-        $payload = [
-            'amountDebit'       => 52.30,
-            'description'       => 'in3 pay',
-            'order'             => uniqid(),
-            'invoice'           => uniqid(),
-            'clientIP'      => '127.0.0.1',
-            'billing'       => [
-                'recipient'        => [
-                    'category'      => 'B2C',
-                    'initials'      => 'J',
-                    'firstName'      => 'John',
-                    'lastName'      => 'Dona',
-                    'birthDate'     => '1990-01-01',
-                    'customerNumber'        => '12345',
-                    'phone'                 => '0612345678',
-                    'country'               => 'NL',
-                    'companyName' => 'My Company B.V.',
-                    'chamberOfCommerce' => '123456'
-                ],
-                'address' => [
-                    'street' => 'Hoofdstraat',
-                    'houseNumber' => '13',
-                    'houseNumberAdditional' => 'a',
-                    'zipcode' => '1234AB',
-                    'city' => 'Heerenveen',
-                    'country' => 'NL',
-                ],
-                'phone' => [
-                    'phone' => '0698765433',
-                ],
-                'email' => 'test@buckaroo.nl',
-            ],
-            'shipping' => [
-                'recipient' => [
-                    'category' => 'B2C',
-                    'careOf' => 'John Smith',
-                    'firstName' => 'John',
-                    'lastName' => 'Do',
-                    'chamberOfCommerce' => '123456'
-                ],
-                'address' => [
-                    'street' => 'Kalverstraat',
-                    'houseNumber' => '13',
-                    'houseNumberAdditional' => 'b',
-                    'zipcode' => '4321EB',
-                    'city' => 'Amsterdam',
-                    'country' => 'NL',
-                ],
-            ],
-            'articles' => [
-                [
-                    'identifier' => 'Articlenumber1',
-                    'type' => 'Physical',
-                    'description' => 'Blue Toy Car',
-                    'category' => 'test product',
-                    'vatPercentage' => '21',
-                    'quantity' => '2',
-                    'price' => '20.10',
-                ],
-                [
-                    'identifier' => 'Articlenumber2',
-                    'type' => 'Physical',
-                    'description' => 'Red Toy Car',
-                    'category' => 'test product',
-                    'vatPercentage' => '21',
-                    'quantity' => '1',
-                    'price' => '10.10',
-                ],
-                [
-                    'identifier' => 'USPShippingID',
-                    'type' => 'Physical',
-                    'description' => 'UPS',
-                    'category' => 'test product',
-                    'vatPercentage' => '21',
-                    'quantity' => '1',
-                    'price' => '2',
-                ],
-            ]
-        ];
-
-        if ($additional)
-        {
-            return array_merge($additional, $payload);
-        }
-
-        return $payload;
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/KBCTest.php
+++ b/tests/Buckaroo/Payments/KBCTest.php
@@ -24,23 +24,25 @@ use Tests\Buckaroo\BuckarooTestCase;
 
 class KBCTest extends BuckarooTestCase
 {
-    protected array $paymentPayload;
-
-    protected function setUp(): void
-    {
-        $this->paymentPayload = ([
-            'invoice' => uniqid(),
-            'amountDebit' => 10.10,
-        ]);
-    }
-
     /**
      * @return void
      * @test
      */
     public function it_creates_a_kbc_payment()
     {
-        $response = $this->buckaroo->method('kbcpaymentbutton')->pay($this->paymentPayload);
+        $response = $this->buckaroo->method('kbcpaymentbutton')->pay($this->getBasePayPayload());
         $this->assertTrue($response->isPendingProcessing());
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function it_creates_a_kbc_refund()
+    {
+        $response = $this->buckaroo->method('kbcpaymentbutton')->refund($this->getRefundPayload([
+            'originalTransactionKey' => '150355695CBD47CC8A0D7F14E994F202'
+        ]));
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/KlarnaKPTest.php
+++ b/tests/Buckaroo/Payments/KlarnaKPTest.php
@@ -20,22 +20,10 @@
 
 namespace Tests\Buckaroo\Payments;
 
-use Buckaroo\Resources\Constants\RecipientCategory;
 use Tests\Buckaroo\BuckarooTestCase;
 
 class KlarnaKPTest extends BuckarooTestCase
 {
-    /**
-     * @return void
-     * @test
-     */
-    public function it_creates_a_klarnakp_payment()
-    {
-        $response = $this->buckaroo->method('klarnakp')->pay($this->getPaymentPayload());
-
-        $this->assertTrue($response->isSuccess());
-    }
-
     /**
      * @return void
      * @test
@@ -45,6 +33,19 @@ class KlarnaKPTest extends BuckarooTestCase
         $response = $this->buckaroo->method('klarnakp')->reserve($this->getPaymentPayload());
 
         $this->assertTrue($response->isPendingProcessing());
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function it_creates_a_klarnakp_payment()
+    {
+        $response = $this->buckaroo->method('klarnakp')->pay($this->getPaymentPayload([
+            'reservationNumber' => 'f055e53d-6da2-4f90-945e-73e65fa391ad',
+        ]));
+
+        $this->assertTrue($response->isSuccess());
     }
 
     /**
@@ -67,27 +68,8 @@ class KlarnaKPTest extends BuckarooTestCase
     public function it_creates_a_klarnakp_update_reservation()
     {
         $response = $this->buckaroo->method('klarnakp')->updateReserve([
-            'invoice' => 'testinvoice 1234',
-            'billing' => [
-                'recipient' => [
-                    'careOf' => 'Person',
-                    'firstName' => 'John',
-                    'lastName' => 'Do',
-                ],
-                'address' => [
-                    'street' => 'Hoofdstraat',
-                    'houseNumber' => '13',
-                    'houseNumberAdditional' => 'a',
-                    'zipcode' => '1234AB',
-                    'city' => 'Heerenveen',
-                    'country' => 'GB',
-                ],
-                'phone' => [
-                    'mobile' => '0698765433',
-                    'landLine' => '0109876543',
-                ],
-                'email' => 'test@buckaroo.nl',
-            ],
+            'reservationNumber' => '3a9c8f5d-ffef-4f53-af40-2c1198539d6d',
+            'invoice' => 'testinvoice 12345',
             'shipping' => [
                 'recipient' => [
                     'careOf' => 'Company',
@@ -111,8 +93,6 @@ class KlarnaKPTest extends BuckarooTestCase
                     'vatPercentage' => '21',
                     'quantity' => '2',
                     'price' => '20.10',
-                    'imageUrl' => 'https://example.com/image',
-                    'productUrl' => 'https://example.com/product',
                 ],
                 [
                     'identifier' => 'Articlenumber2',
@@ -120,13 +100,11 @@ class KlarnaKPTest extends BuckarooTestCase
                     'vatPercentage' => '21',
                     'quantity' => '1',
                     'price' => '10.10',
-                    'imageUrl' => 'https://example.com/image',
-                    'productUrl' => 'https://example.com/product',
                 ],
             ],
         ]);
 
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isSuccess());
     }
 
     /**
@@ -135,77 +113,27 @@ class KlarnaKPTest extends BuckarooTestCase
      */
     public function it_creates_a_klarnakp_refund()
     {
-        $response = $this->buckaroo->method('klarnakp')->refund([
-            'amountCredit' => 10,
-            'invoice' => '10000480',
-            'originalTransactionKey' => '9AA4C81A08A84FA7B68E6A6A6291XXXX',
-        ]);
+        $response = $this->buckaroo->method('klarnakp')->refund($this->getRefundPayload([
+            'originalTransactionKey' => 'FB4E1A0F4D714B19BF9272D3B826E09A',
+        ]));
 
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isSuccess());
     }
 
     private function getPaymentPayload(?array $additional = null): array
     {
-        $payload = [
-            'clientIP' => '198.162.1.1',
-            'currency' => 'EUR',
-            'amountDebit' => 50.30,
-            'order' => uniqid(),
-            'invoice' => uniqid(),
-            'gender' => "1",
-            'operatingCountry' => 'NL',
-            'billing' => [
-                'recipient' => [
-                    'firstName' => 'John',
-                    'lastName' => 'Do',
-                ],
-                'address' => [
-                    'street' => 'Neherkade',
-                    'houseNumber' => '1',
-                    'zipcode' => '2521VA',
-                    'city' => 'Gravenhage',
-                    'country' => 'NL',
-                ],
-                'phone' => [
-                    'mobile' => '0612345678',
-                ],
-                'email' => 'youremail@example.nl',
-            ],
-            'shipping' => [
-                'recipient' => [
-                    'firstName' => 'John',
-                    'lastName' => 'Do',
-                ],
-                'address' => [
-                    'street' => 'Rosenburglaan',
-                    'houseNumber' => '216',
-                    'zipcode' => '4385 JM',
-                    'city' => 'Vlissingen',
-                    'country' => 'NL',
-                ],
-                'email' => 'test@buckaroo.nl',
-            ],
-            'articles' => [
-                [
-                    'identifier' => 'Articlenumber1',
-                    'description' => 'Blue Toy Car',
-                    'vatPercentage' => '21',
-                    'quantity' => '2',
-                    'price' => '20.10',
-                    'imageUrl' => 'https://example.com/image',
-                    'productUrl' => 'https://example.com/product',
-                ],
-                [
-                    'identifier' => 'Articlenumber2',
-                    'description' => 'Red Toy Car',
-                    'vatPercentage' => '21',
-                    'quantity' => '1',
-                    'price' => '10.10',
-                    'imageUrl' => 'https://example.com/image',
-                    'productUrl' => 'https://example.com/product',
-                ],
+        $payload = array_merge(
+            $this->getBasePayPayload([], [
+                'clientIP' => '198.162.1.1',
+                'gender' => "1",
+                'operatingCountry' => 'NL',
+            ]),
+            [
+                'billing' => $this->getBillingPayload(['careOf', 'title', 'initials', 'category', 'birthDate']),
+                'shipping' => $this->getShippingPayload(['careOf', 'title', 'initials', 'category', 'birthDate']),
+                'articles' => $this->getArticlesPayload(),
             ]
-        ];
+        );
 
         if ($additional) {
             return array_merge($additional, $payload);

--- a/tests/Buckaroo/Payments/KlarnaTest.php
+++ b/tests/Buckaroo/Payments/KlarnaTest.php
@@ -41,139 +41,28 @@ class KlarnaTest extends BuckarooTestCase
      */
     public function it_creates_a_klarna_payment_installment()
     {
-        $response = $this->buckaroo->method('klarna')->payInInstallments($this->getPaymentInstallmentPayload());
+        $response = $this->buckaroo->method('klarna')->payInInstallments($this->getPaymentPayload('GB', 'GBP'));
 
         $this->assertTrue($response->isPendingProcessing());
     }
 
-    private function getPaymentPayload(): array
+    private function getPaymentPayload(string $country = 'NL', string $currency = 'EUR'): array
     {
-        return [
-            'amountDebit' => 50.30,
-            'order' => uniqid(),
-            'invoice' => uniqid(),
-            'billing' => [
-                'recipient' => [
-                    'category' => 'B2C',
-                    'gender' => 'female',
-                    'firstName' => 'John',
-                    'lastName' => 'Do',
-                    'birthDate' => '1990-01-01',
-                ],
-                'address' => [
-                    'street' => 'Hoofdstraat',
-                    'houseNumber' => '13',
-                    'houseNumberAdditional' => 'a',
-                    'zipcode' => '1234AB',
-                    'city' => 'Heerenveen',
-                    'country' => 'NL',
-                ],
-                'phone' => [
-                    'mobile' => '0698765433',
-                    'landline' => '0109876543',
-                ],
-                'email' => 'test@buckaroo.nl',
-            ],
-            'shipping' => [
-                'recipient' => [
-                    'category' => 'B2B',
-                    'gender' => 'male',
-                    'firstName' => 'John',
-                    'lastName' => 'Do',
-                    'birthDate' => '1990-01-01',
-                ],
-                'address' => [
-                    'street' => 'Kalverstraat',
-                    'houseNumber' => '13',
-                    'houseNumberAdditional' => 'b',
-                    'zipcode' => '4321EB',
-                    'city' => 'Amsterdam',
-                    'country' => 'NL',
-                ],
-                'email' => 'test@buckaroo.nl',
-            ],
-            'articles' => [
-                [
-                    'identifier' => 'Articlenumber1',
-                    'description' => 'Blue Toy Car',
-                    'vatPercentage' => '21',
-                    'quantity' => '2',
-                    'price' => '20.10',
-                ],
-                [
-                    'identifier' => 'Articlenumber2',
-                    'description' => 'Red Toy Car',
-                    'vatPercentage' => '21',
-                    'quantity' => '1',
-                    'price' => '10.10',
-                ],
-            ],
-        ];
-    }
+        $payload = array_merge(
+            $this->getBasePayPayload([],[
+                'currency' => $currency,
+            ]),
+            [
+                'billing' => $this->getBillingPayload(['careOf', 'title', 'initials']),
+                'shipping' => $this->getShippingPayload(['careOf', 'title', 'initials']),
+                'articles' => $this->getArticlesPayload(),
+            ]
+            );
+        $payload['billing']['address']['country'] = $country;
+        $payload['billing']['recipient']['gender'] = 'female';
+        $payload['shipping']['address']['country'] = $country;
+        $payload['shipping']['recipient']['gender'] = 'male';
 
-    private function getPaymentInstallmentPayload(): array
-    {
-        return [
-            'amountDebit' => 50.30,
-            'order' => uniqid(),
-            'invoice' => uniqid(),
-            'currency' => 'GBP',
-            'billing' => [
-                'recipient' => [
-                    'category' => 'B2C',
-                    'gender' => 'female',
-                    'firstName' => 'John',
-                    'lastName' => 'Do',
-                    'birthDate' => '1990-01-01',
-                ],
-                'address' => [
-                    'street' => 'Hoofdstraat',
-                    'houseNumber' => '13',
-                    'houseNumberAdditional' => 'a',
-                    'zipcode' => '1234AB',
-                    'city' => 'Heerenveen',
-                    'country' => 'GB',
-                ],
-                'phone' => [
-                    'mobile' => '0698765433',
-                    'landline' => '0109876543',
-                ],
-                'email' => 'test@buckaroo.nl',
-            ],
-            'shipping' => [
-                'recipient' => [
-                    'category' => 'B2B',
-                    'gender' => 'male',
-                    'firstName' => 'John',
-                    'lastName' => 'Do',
-                    'birthDate' => '1990-01-01',
-                ],
-                'address' => [
-                    'street' => 'Kalverstraat',
-                    'houseNumber' => '13',
-                    'houseNumberAdditional' => 'b',
-                    'zipcode' => '4321EB',
-                    'city' => 'Amsterdam',
-                    'country' => 'GB',
-                ],
-                'email' => 'test@buckaroo.nl',
-            ],
-            'articles' => [
-                [
-                    'identifier' => 'Articlenumber1',
-                    'description' => 'Blue Toy Car',
-                    'vatPercentage' => '21',
-                    'quantity' => '2',
-                    'price' => '20.10',
-                ],
-                [
-                    'identifier' => 'Articlenumber2',
-                    'description' => 'Red Toy Car',
-                    'vatPercentage' => '21',
-                    'quantity' => '1',
-                    'price' => '10.10',
-                ],
-            ],
-        ];
+        return $payload;
     }
 }

--- a/tests/Buckaroo/Payments/KnakenPayTest.php
+++ b/tests/Buckaroo/Payments/KnakenPayTest.php
@@ -30,32 +30,32 @@ class KnakenPayTest extends BuckarooTestCase
      */
     public function it_creates_a_knaken_payment()
     {
-        $response = $this->buckaroo->method('knaken')->pay([
+        $response = $this->buckaroo->method('knaken')->pay($this->getBasePayPayload([],[
+            'returnURL'=> 'https://example.com/buckaroo/return',
+            'returnURLCancel' => 'https://example.com/buckaroo/cancel',
+            'returnURLError' => 'https://example.com/buckaroo/error',
+            'returnURLReject' => 'https://example.com/buckaroo/reject',
+            'pushURL' => 'https://example.com/buckaroo/push',
+            'returnURLCancel' => 'https://example.com/buckaroo/cancel',
+            'pushURLFailure' => 'https://example.com/buckaroo/push-failure',
             'invoice'               => uniqid(),
-            'amountDebit'           => 10.99,
-            'returnURL'             => 'https://buckaroo.dev./return',
-            'returnURLCancel'       => 'https://buckaroo.dev/cancel',
-            'returnURLError'        => 'https://buckaroo.dev/error',
-            'returnURLReject'       => 'https://buckaroo.dev/reject',
-            'pushURL'               => 'https://buckaroo.dev/push',
-            'pushURLFailure'        => 'https://buckaroo.dev/push-failure',
-        ]);
+            'amountDebit'           => 0.1,
+            "CustomerName"=> "Rico",
+        ]));
 
         $this->assertTrue($response->isPendingProcessing());
     }
 
+    // Only one refund allowed per transaction
     /**
      * @test
      */
     public function it_creates_a_knaken_refund()
     {
-        $response = $this->buckaroo->method('knaken')->refund([
-            'invoice' => '2024020209061234', //Set invoice number of the transaction to refund
-            'originalTransactionKey' => '2FBB9F43A0AF4AC8B49F9073C0EC828B',
-            //Set transaction key of the transaction to refund
-            'amountCredit' => 0.01
-        ]);
+        $response = $this->buckaroo->method('knaken')->refund($this->getRefundPayload([
+            'originalTransactionKey' => 'E29EB7DF6EA8448A87FC6A03E6EFA0A3',
+        ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/MBWayTest.php
+++ b/tests/Buckaroo/Payments/MBWayTest.php
@@ -30,10 +30,7 @@ class MBWayTest extends BuckarooTestCase
      */
     public function it_creates_a_mbway_payment()
     {
-        $response = $this->buckaroo->method('mbway')->pay([
-            'invoice' => uniqid(),
-            'amountDebit' => 10.10,
-        ]);
+        $response = $this->buckaroo->method('mbway')->pay($this->getBasePayPayload());
 
         $this->assertTrue($response->isPendingProcessing());
     }
@@ -43,13 +40,10 @@ class MBWayTest extends BuckarooTestCase
      */
     public function it_creates_a_mbway_refund()
     {
-        $response = $this->buckaroo->method('mbway')->refund([
-            'amountCredit' => 10,
-            'invoice' => 'testinvoice 123',
-            'description' => 'refund',
-            'originalTransactionKey' => '2D04704995B74D679AACC59F87XXXXXX',
-        ]);
+        $response = $this->buckaroo->method('mbway')->refund($this->getRefundPayload([
+            'originalTransactionKey' => '83A9AD305D71405FAC3D3E37DBA51D99',
+        ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/MultibancoTest.php
+++ b/tests/Buckaroo/Payments/MultibancoTest.php
@@ -30,10 +30,7 @@ class MultibancoTest extends BuckarooTestCase
      */
     public function it_creates_a_multibanco_payment()
     {
-        $response = $this->buckaroo->method('multibanco')->pay([
-            'invoice' => uniqid(),
-            'amountDebit' => 10.10,
-        ]);
+        $response = $this->buckaroo->method('multibanco')->pay($this->getBasePayPayload());
 
         $this->assertTrue($response->isPendingProcessing());
     }
@@ -43,13 +40,10 @@ class MultibancoTest extends BuckarooTestCase
      */
     public function it_creates_a_multibanco_refund()
     {
-        $response = $this->buckaroo->method('multibanco')->refund([
-            'amountCredit' => 10,
-            'invoice' => 'testinvoice 123',
-            'description' => 'refund',
-            'originalTransactionKey' => '2D04704995B74D679AACC59F87XXXXXX',
-        ]);
+        $response = $this->buckaroo->method('multibanco')->refund($this->getRefundPayload([
+            'originalTransactionKey' => '9BDDFD2D455A41298713089E7056FADF',
+        ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/NoServiceSpecifiedPaymentTest.php
+++ b/tests/Buckaroo/Payments/NoServiceSpecifiedPaymentTest.php
@@ -29,13 +29,11 @@ class NoServiceSpecifiedPaymentTest extends BuckarooTestCase
      */
     public function it_creates_a_noservice_payment()
     {
-        $response = $this->buckaroo->method('noservice')->pay([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
-            'servicesSelectableByClient' => 'ideal,bancontactmrcash,paypal',
+        $response = $this->buckaroo->method('noservice')->pay($this->getBasePayPayload([], [
+            'servicesSelectableByClient' => 'ideal,mbway,bancontactmrcash,paypal',
             'servicesExcludedForClient' => 'ideal',
             'continueOnIncomplete' => '1',
-        ]);
+        ]));
 
         $this->assertTrue($response->isWaitingOnUserInput());
     }

--- a/tests/Buckaroo/Payments/PayPerEmailTest.php
+++ b/tests/Buckaroo/Payments/PayPerEmailTest.php
@@ -48,32 +48,4 @@ class PayPerEmailTest extends BuckarooTestCase
 
         $this->assertTrue($response->isAwaitingConsumer());
     }
-
-    /**
-     * @return void
-     * @test
-     */
-    public function it_invites_pay_per_email_with_attachments()
-    {
-        $response = $this->buckaroo->method('payperemail')->paymentInvitation([
-            'amountDebit' => 10,
-            'invoice' => 'testinvoice 123',
-            'merchantSendsEmail' => false,
-            'email' => 'johnsmith@gmail.com',
-            'expirationDate' => '2030-01-01',
-            'paymentMethodsAllowed' => 'ideal,mastercard,paypal',
-            'attachment' => '',
-            'customer' => [
-                'gender' => Gender::FEMALE,
-                'firstName' => 'John',
-                'lastName' => 'Smith',
-            ],
-            'attachments' => [
-                ['name' => 'bijlage1.pdf'],
-                ['name' => 'bijlage2.pdf'],
-            ],
-        ]);
-
-        $this->assertTrue($response->isFailed());
-    }
 }

--- a/tests/Buckaroo/Payments/PayconiqTest.php
+++ b/tests/Buckaroo/Payments/PayconiqTest.php
@@ -29,11 +29,7 @@ class PayconiqTest extends BuckarooTestCase
      */
     public function it_creates_a_payconiq_payment()
     {
-        $response = $this->buckaroo->method('payconiq')->pay([
-            'amountDebit' => 10,
-            'description' => 'Payment for testinvoice123',
-            'invoice' => uniqid(),
-        ]);
+        $response = $this->buckaroo->method('payconiq')->pay($this->getBasePayPayload());
 
         $this->assertTrue($response->isPendingProcessing());
     }
@@ -43,12 +39,10 @@ class PayconiqTest extends BuckarooTestCase
      */
     public function it_creates_a_payconiq_refund()
     {
-        $response = $this->buckaroo->method('payconiq')->refund([
-            'amountCredit' => 10,
-            'invoice' => 'testinvoice 123',
-            'originalTransactionKey' => '4E8BD922192746C3918BF4077CXXXXXX',
-        ]);
+        $response = $this->buckaroo->method('payconiq')->refund($this->getRefundPayload([
+            'originalTransactionKey' => '3531593A0AC04B449B6CAE51FE1D6DE7',
+        ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/PaymentInitiationTest.php
+++ b/tests/Buckaroo/Payments/PaymentInitiationTest.php
@@ -28,15 +28,13 @@ class PaymentInitiationTest extends BuckarooTestCase
      */
     public function it_creates_a_payment_initiation_payment()
     {
-        $response = $this->buckaroo->method('paybybank')->pay([
-            'amountDebit' => 10,
-            'description' => 'Payment for testinvoice123',
-            'invoice' => uniqid(),
+        $response = $this->buckaroo->method('paybybank')->pay($this->getBasePayPayload([], [
             'issuer' => 'ABNANL2A',
-            'countryCode' => 'NL'
-        ]);
+            'countryCode' => 'NL',
+            'pushURL' => 'https://example.com/buckaroo/push',
+        ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isPendingProcessing());
     }
 
     /**
@@ -44,12 +42,12 @@ class PaymentInitiationTest extends BuckarooTestCase
      */
     public function it_creates_a_payment_initiation_refund()
     {
-        $response = $this->buckaroo->method('paybybank')->refund([
-            'amountCredit' => 10,
-            'invoice' => 'testinvoice 123',
-            'originalTransactionKey' => '4E8BD922192746C3918BF4077CXXXXXX',
-        ]);
+        $response = $this->buckaroo->method('paybybank')->refund($this->getRefundPayload([
+            'originalTransactionKey' => 'F7B4C318221D41F185728116F05C9EF7',
+            'invoice' => '670fa9e86d347',
+            'pushURL' => 'https://example.com/buckaroo/push',
+        ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/PaypalTest.php
+++ b/tests/Buckaroo/Payments/PaypalTest.php
@@ -29,10 +29,7 @@ class PaypalTest extends BuckarooTestCase
      */
     public function it_creates_a_paypal_payment()
     {
-        $response = $this->buckaroo->method('paypal')->pay([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
-        ]);
+        $response = $this->buckaroo->method('paypal')->pay($this->getBasePayPayload());
 
         $this->assertTrue($response->isPendingProcessing());
     }
@@ -42,13 +39,11 @@ class PaypalTest extends BuckarooTestCase
      */
     public function it_creates_a_paypal_recurrent_payment()
     {
-        $response = $this->buckaroo->method('paypal')->payRecurrent([
-            'amountDebit' => 10,
-            'originalTransactionKey' => 'C32C0B52E1FE4A37835FFB1716XXXXXX',
-            'invoice' => uniqid(),
-        ]);
+        $response = $this->buckaroo->method('paypal')->payRecurrent($this->getBasePayPayload([],[
+            'originalTransactionKey' => '8E84AF7D9BDF45368D60AC4ED7EA1733',
+        ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 
     /**
@@ -56,9 +51,7 @@ class PaypalTest extends BuckarooTestCase
      */
     public function it_creates_a_paypal_extra_info()
     {
-        $response = $this->buckaroo->method('paypal')->extraInfo([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
+        $response = $this->buckaroo->method('paypal')->extraInfo($this->getBasePayPayload([],[
             'customer' => [
                 'name' => 'John Smith',
             ],
@@ -73,7 +66,7 @@ class PaypalTest extends BuckarooTestCase
             'phone' => [
                 'mobile' => '0612345678',
             ],
-        ]);
+        ]));
 
         $this->assertTrue($response->isPendingProcessing());
     }
@@ -83,85 +76,32 @@ class PaypalTest extends BuckarooTestCase
      */
     public function it_creates_a_paypal_refund()
     {
-        $response = $this->buckaroo->method('paypal')->refund([
-            'amountCredit' => 10,
-            'invoice' => 'testinvoice 123',
-            'originalTransactionKey' => '2D04704995B74D679AACC59F87XXXXXX',
-        ]);
+        $response = $this->buckaroo->method('paypal')->refund($this->getRefundPayload([
+            'originalTransactionKey' => 'CE26373CFB64485CB7DFB1BD656066C1',
+        ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 
     /**
      * @test
      */
-    public function it_creates_a_combined_subscriptions_with_paypal_and_extra_info()
+    public function it_creates_a_paypal_pay_remainder()
     {
-        $subscriptions = $this->buckaroo->method('subscriptions')->manually()->createCombined([
-            'pushURL' => 'https://buckaroo.dev/push',
-            'includeTransaction' => false,
-            'transactionVatPercentage' => 5,
-            'configurationCode' => 'gfyh9fe4',
-            'email' => 'test@buckaroo.nl',
-            'ratePlans' => [
-                'add' => [
-                    'startDate' => '2033-01-01',
-                    'ratePlanCode' => '9863hdcj',
-                ],
-            ],
-            'phone' => [
-                'mobile' => '0612345678',
-            ],
-            'debtor' => [
-                'code' => 'johnsmith4',
-            ],
-//            'person'                    => [
-//                'firstName'         => 'John',
-//                'lastName'          => 'Do',
-//                'gender'            => Gender::FEMALE,
-//                'culture'           => 'nl-NL',
-//                'birthDate'         => '1990-01-01'
-//            ],
-            'company' => [
-                'culture' => 'nl-NL',
-                'companyName' => 'My Company Coporation',
-                'vatApplicable' => true,
-                'vatNumber' => 'NL140619562B01',
-                'chamberOfCommerce' => '20091741',
-            ],
-            'address' => [
-                'street' => 'Hoofdstraat',
-                'houseNumber' => '90',
-                'zipcode' => '8441ER',
-                'city' => 'Heerenveen',
-                'country' => 'NL',
-            ],
-        ]);
-
-        $paypal_extra_info = $this->buckaroo->method('paypal')->manually()->extraInfo([
+        $giftCardResponse = $this->buckaroo->method('giftcard')->pay($this->getBasePayPayload([], [
             'amountDebit' => 10,
-            'invoice' => uniqid(),
-            'customer' => [
-                'name' => 'John Smith',
-            ],
-            'address' => [
-                'street' => 'Hoofstraat 90',
-                'street2' => 'Street 2',
-                'city' => 'Heerenveen',
-                'state' => 'Friesland',
-                'zipcode' => '8441AB',
-                'country' => 'NL',
-            ],
-            'phone' => [
-                'mobile' => '0612345678',
-            ],
-        ]);
+            'name' => 'boekenbon',
+            'intersolveCardnumber' => '0000000000000000001',
+            'intersolvePIN' => '500',
+        ]));
 
-        $response = $this->buckaroo->method('paypal')->combine([$subscriptions, $paypal_extra_info])->pay([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
-        ]);
+        $this->assertTrue($giftCardResponse->isSuccess());
 
-        $this->assertTrue($response->isValidationFailure());
+        $response = $this->buckaroo->method('paypal')->payRemainder($this->getBasePayPayload([], [
+            'originalTransactionKey' => $giftCardResponse->data('RelatedTransactions')[0]['RelatedTransactionKey'],
+            'amountDebit' => 9.50,
+        ]));
+
+        $this->assertTrue($response->isPendingProcessing());
     }
 }

--- a/tests/Buckaroo/Payments/PosTest.php
+++ b/tests/Buckaroo/Payments/PosTest.php
@@ -30,11 +30,9 @@ class PosTest extends BuckarooTestCase
      */
     public function it_creates_a_pos_payment()
     {
-        $response = $this->buckaroo->method('pospayment')->pay([
-            'invoice' => uniqid(),
-            'amountDebit' => 10.10,
+        $response = $this->buckaroo->method('pospayment')->pay($this->getBasePayPayload([],[
             'terminalID' => '50000001',
-        ]);
+        ]));
 
         $this->assertTrue($response->isSuccess());
     }

--- a/tests/Buckaroo/Payments/PushTest.php
+++ b/tests/Buckaroo/Payments/PushTest.php
@@ -30,59 +30,19 @@ class PushTest extends BuckarooTestCase
      */
     public function it_test_the_push_response()
     {
-//        $data = [
-//            'test' => 'test'
-//        ];
-//        $generator = new Generator($this->buckaroo->client()->config(), $data, 'https://buckaroo.com/push');
-//        $generator->generate();
-
-
-        $replyHandler = $this->buckaroo->method('ideal');
-
-        $auth_header = 'IBjihN7Fhp:0YvyjYAzDQ28W+hQi80f2nhe0Z1QFJLbz7IH//6LsAU=:cad1832100784f57a6e6de835d9f3638:
-        1658227572';
-        $post_data = '{"Transaction":{"Key":"5340604668D74435AA344E1428ED1292","Invoice":"62d68b6c8ab0c",
-        "ServiceCode":"ideal","Status":{"Code":{"Code":190,"Description":"Success"},"SubCode":{"Code":"S001",
-        "Description":"Transaction successfully processed"},"DateTime":"2022-07-19T12:46:12"},"IsTest":true,
-        "Order":"ORDER_NO_62d68b6ca2df3","Currency":"EUR","AmountDebit":10.1,"TransactionType":"C021",
-        "Services":[{"Name":"ideal","Action":null,"Parameters":[{"Name":"consumerIssuer","Value":"ABN AMRO"},
-        {"Name":"transactionId","Value":"0000000000000001"},{"Name":"consumerName","Value":"J. de Tèster"},
-        {"Name":"consumerIBAN","Value":"NL44RABO0123456789"},{"Name":"consumerBIC","Value":"RABONL2U"}],
-        "VersionAsProperty":2}],"CustomParameters":null,"AdditionalParameters":{"List":[{"Name":
-        "initiated_by_magento","Value":"1"},{"Name":"service_action","Value":"something"}]},"MutationType":1,
-        "RelatedTransactions":null,"IsCancelable":false,"IssuingCountry":null,"StartRecurrent":false,
-        "Recurring":false,"CustomerName":"J. de Tèster","PayerHash":"2d26d34584a4eafeeaa97eed10cfdae22ae64cdce
-        1649a80a55fafca8850e3e22cb32eb7c8fc95ef0c6f96669a21651d4734cc568816f9bd59c2092911e6c0da","PaymentKey":
-        "AEC974D455FF4A4B9B4C21E437A04838","Description":null}}';
+        $post_data = '{"Transaction":{"Key":"308E1CE5A7914DCC9212040A4DB17528","Invoice":"RqovbgXe4o4Ejvqt","ServiceCode":"afterpay","Status":{"Code":{"Code":190,"Description":"Success"},"SubCode":{"Code":"S990","Description":"The request was successful."},"DateTime":"2024-11-25T13:51:10"},"IsTest":true,"Order":"RqovbgXe4o4Ejvqt","Currency":"EUR","AmountDebit":79.95,"TransactionType":"C039","Services":null,"CustomParameters":null,"AdditionalParameters":null,"MutationType":1,"RelatedTransactions":null,"IsCancelable":false,"IssuingCountry":"NL","StartRecurrent":false,"Recurring":false,"CustomerName":"Test Vries","PayerHash":null,"PaymentKey":"D215D7F62CEF41308B2230EAE3BC85A1","Description":"buckaroo 2130"}}';
         $uri = 'https://buckaroo.dev/push';
+        $timestamp = '1732545581';
+        $nonce = 'ac9bcf061ac14a02b7e52b2328119de5';
 
-        $post_data = [
-            "brq_amount" => "10.10",
-            "brq_currency" => "EUR",
-            "brq_customer_name" => "J. de Tèster",
-            "brq_invoicenumber" => "SDKDevelopment.com_INVOICE_NO_628c6d032af90",
-            "brq_ordernumber" => "SDKDevelopment.com_ORDER_NO_628c6d032af95",
-            "brq_payer_hash" => "2d26d34584a4eafeeaa97eed10cfdae22ae64cdce1649a80a55fafca8850e3e22cb32eb7
-            c8fc95ef0c6f96669a21651d4734cc568816f9bd59c2092911e6c0da",
-            "brq_payment" => "D44ACDD0F99D4A1C811D2CD3EFDB05BA",
-            "brq_payment_method" => "ideal",
-            "brq_SERVICE_ideal_consumerBIC" => "RABONL2U",
-            "brq_SERVICE_ideal_consumerIBAN" => "NL44RABO0123456789",
-            "brq_SERVICE_ideal_consumerIssuer" => "ABN AMRO",
-            "brq_SERVICE_ideal_consumerName" => "J. de Tèster",
-            "brq_SERVICE_ideal_transactionId" => "0000000000000001",
-            "brq_statuscode" => "190",
-            "brq_statuscode_detail" => "S001",
-            "brq_statusmessage" => "Transaction successfully processed",
-            "brq_test" => "true",
-            "brq_timestamp" => "2022-05-24 07:29:09",
-            "brq_transactions" => "4C1BE53E2C42412AB32A799D9316E7DD",
-            "brq_websitekey" => "IBjihN7Fhp",
-            "brq_signature" => "bf7a62c830da2d2e004199919a8fe0d53b0668f5",
-        ];
+        $md5 = md5($post_data, true);
+        $base64Data = base64_encode($md5);
+        $hmac = $_ENV['BPE_WEBSITE_KEY'] . 'POST' . 'buckaroo.dev%2fpush' . $timestamp . $nonce . $base64Data;
+        $hash = base64_encode(hash_hmac('sha256', $hmac, $_ENV['BPE_SECRET_KEY'], true));
+
+        $auth_header = "{$_ENV['BPE_WEBSITE_KEY']}:{$hash}:{$nonce}:{$timestamp}";
 
         $reply_handler = new ReplyHandler($this->buckaroo->client()->config(), $post_data, $auth_header, $uri);
-
         $reply_handler->validate();
 
         $this->assertTrue($reply_handler->isValid());

--- a/tests/Buckaroo/Payments/SepaTest.php
+++ b/tests/Buckaroo/Payments/SepaTest.php
@@ -16,6 +16,7 @@ class SepaTest extends BuckarooTestCase
         $response = $this->buckaroo->method('sepadirectdebit')->pay($this->getBasePayPayload([], [
             'iban' => 'NL13TEST0123456789',
             'bic' => 'TESTNL2A',
+            'startRecurrent' => true,
             'collectdate' => '2022-12-01',
             'mandateReference' => '1DCtestreference',
             'mandateDate' => '2022-07-03',
@@ -64,7 +65,6 @@ class SepaTest extends BuckarooTestCase
         $this->assertTrue($response->isSuccess());
     }
 
-    //Todo: Failing
     /**
      * @return void
      * @test
@@ -72,12 +72,11 @@ class SepaTest extends BuckarooTestCase
     public function it_creates_a_sepa_recurrent_payment()
     {
         $response = $this->buckaroo->method('sepadirectdebit')->payRecurrent($this->getBasePayPayload([], [
-            'originalTransactionKey' => '9D2855A4ED164EE7954E71E3154873DE',
+            'originalTransactionKey' => '3CE4E4D07CE74B5BBD78809DE6671B75',
             'collectdate' => '2030-07-03',
-            'order' => '',
         ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isPendingProcessing());
     }
 
     /**

--- a/tests/Buckaroo/Payments/SepaTest.php
+++ b/tests/Buckaroo/Payments/SepaTest.php
@@ -6,13 +6,14 @@ use Tests\Buckaroo\BuckarooTestCase;
 
 class SepaTest extends BuckarooTestCase
 {
-    protected array $paymentPayload;
 
-    protected function setUp(): void
+    /**
+     * @return void
+     * @test
+     */
+    public function it_creates_a_sepa_payment()
     {
-        $this->paymentPayload = ([
-            'invoice' => uniqid(),
-            'amountDebit' => 10.10,
+        $response = $this->buckaroo->method('sepadirectdebit')->pay($this->getBasePayPayload([], [
             'iban' => 'NL13TEST0123456789',
             'bic' => 'TESTNL2A',
             'collectdate' => '2022-12-01',
@@ -21,16 +22,7 @@ class SepaTest extends BuckarooTestCase
             'customer' => [
                 'name' => 'John Smith',
             ],
-        ]);
-    }
-
-    /**
-     * @return void
-     * @test
-     */
-    public function it_creates_a_sepa_payment()
-    {
-        $response = $this->buckaroo->method('sepadirectdebit')->pay($this->paymentPayload);
+        ]));
 
         $this->assertTrue($response->isPendingProcessing());
     }
@@ -41,13 +33,11 @@ class SepaTest extends BuckarooTestCase
      */
     public function it_creates_a_sepa_refund()
     {
-        $response = $this->buckaroo->method('sepadirectdebit')->refund([
-            'amountCredit' => 10,
-            'invoice' => 'testinvoice 123',
-            'originalTransactionKey' => '3D175524FCF94C94A23B67E8DCXXXXXX',
-        ]);
+        $response = $this->buckaroo->method('sepadirectdebit')->refund($this->getRefundPayload([
+            'originalTransactionKey' => '5221F6CECF4E4C7791BB57BC78C0CF7A',
+        ]));
 
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isSuccess());
     }
 
     /**
@@ -56,23 +46,36 @@ class SepaTest extends BuckarooTestCase
      */
     public function it_creates_a_sepa_authorize()
     {
-        $response = $this->buckaroo->method('sepadirectdebit')->authorize($this->paymentPayload);
+        $response = $this->buckaroo->method('sepadirectdebit')->authorize([
+            'amountDebit' => 10,
+            'invoice' => uniqid(),
+            'iban' => 'NL13TEST0123456789',
+            'bic' => 'TESTNL2A',
+            'collectdate' => '2025-12-01',
+            'mandateReference' => '1DC326734AB3084FC7',
+            'mandateDate' => '2025-07-03',
+            'startRecurrent' => true,
+            'channel' => 'BackOffice',
+            'customer' => [
+                'name' => 'John Smith',
+            ],
+        ]);
 
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isSuccess());
     }
 
+    //Todo: Failing
     /**
      * @return void
      * @test
      */
     public function it_creates_a_sepa_recurrent_payment()
     {
-        $response = $this->buckaroo->method('sepadirectdebit')->payRecurrent([
-            'amountDebit' => 10,
-            'originalTransactionKey' => 'FDA9EEEEA53C42BF875C35C6C2B7xxxx',
-            'invoice' => 'testinvoice 123',
+        $response = $this->buckaroo->method('sepadirectdebit')->payRecurrent($this->getBasePayPayload([], [
+            'originalTransactionKey' => '9D2855A4ED164EE7954E71E3154873DE',
             'collectdate' => '2030-07-03',
-        ]);
+            'order' => '',
+        ]));
 
         $this->assertTrue($response->isFailed());
     }
@@ -113,12 +116,11 @@ class SepaTest extends BuckarooTestCase
      */
     public function it_creates_a_sepa_pay_with_emandate()
     {
-        $response = $this->buckaroo->method('sepadirectdebit')->payWithEmandate([
-            'amountDebit' => 10,
-            'invoice' => 'testinvoice 123',
-            'mandateReference' => '001D284C4A887F84756A1425A369997xxxx',
-        ]);
+        $response = $this->buckaroo->method('sepadirectdebit')->payWithEmandate($this->getBasePayPayload([], [
+            'mandateReference' => '1DC326734AB3084FC7',
+            'order' => '',
+        ]));
 
-        $this->assertTrue($response->isValidationFailure());
+        $this->assertTrue($response->isPendingProcessing());
     }
 }

--- a/tests/Buckaroo/Payments/SurepayTest.php
+++ b/tests/Buckaroo/Payments/SurepayTest.php
@@ -31,9 +31,10 @@ class SurepayTest extends BuckarooTestCase
     public function it_verify_with_surepay()
     {
         $response = $this->buckaroo->method('surepay')->verify([
+            'currency' => '',
             'bankAccount' => [
-                'iban' => 'NL13TEST0123456789',
-                'accountName' => 'John Doe',
+                'iban' => 'NLXXTESTXXXXXXXXXX',
+                'accountName' => 'Test Acceptatie',
             ]
         ]);
 

--- a/tests/Buckaroo/Payments/ThunesTest.php
+++ b/tests/Buckaroo/Payments/ThunesTest.php
@@ -21,7 +21,6 @@
 namespace Tests\Buckaroo\Payments;
 
 use Tests\Buckaroo\BuckarooTestCase;
-use Buckaroo\Resources\Constants\RecipientCategory;
 
 class ThunesTest extends BuckarooTestCase
 {
@@ -31,42 +30,10 @@ class ThunesTest extends BuckarooTestCase
      */
     public function it_creates_a_thunes_paymentit_creates_a_thunes_payment()
     {
-        $response = $this->buckaroo->method('thunes')->pay($this->getPaymentPayload());
+        $response = $this->buckaroo->method('thunes')->pay($this->getPayPayload([
+            'name' => 'belfius',
+        ]));
 
-        $this->assertTrue($response->isValidationFailure());
-    }
-
-    /**
-     * @return void
-     * @test
-     */
-    private function getPaymentPayload(?array $additional = null): array
-    {
-        $payload = [
-            'amountDebit'       => 3,
-            'order'             => uniqid(),
-            'invoice'           => uniqid(),
-            'name' => 'monizzeecovoucher',
-            'clientIP'      => '127.0.0.1',
-            'articles' => [
-                [
-                    'identifier' => 'Articlenumber1',
-                    'description' => 'Articledesciption1',
-                    'price' => '1',
-                ],
-                [
-                    'identifier' => 'Articlenumber2',
-                    'description' => 'Articledesciption2',
-                    'price' => '2',
-                ],
-            ]
-        ];
-
-        if ($additional)
-        {
-            return array_merge($additional, $payload);
-        }
-
-        return $payload;
+        $this->assertTrue($response->isPendingProcessing());
     }
 }

--- a/tests/Buckaroo/Payments/TransferTest.php
+++ b/tests/Buckaroo/Payments/TransferTest.php
@@ -31,19 +31,17 @@ class TransferTest extends BuckarooTestCase
      */
     public function it_creates_a_transfer_payment()
     {
-        $response = $this->buckaroo->method('transfer')->pay([
-            'invoice' => uniqid(),
-            'amountDebit' => 10.10,
+        $response = $this->buckaroo->method('transfer')->pay($this->getBasePayPayload([],[
             'email' => 'your@email.com',
             'country' => 'NL',
             'dateDue' => date("Y-m-d"),
-            'sendMail' => true,
+            'sendMail' => false,
             'customer' => [
                 'gender' => Gender::MALE,
                 'firstName' => 'John',
                 'lastName' => 'Smith',
             ],
-        ]);
+        ]));
 
         $this->assertTrue($response->isAwaitingConsumer());
     }
@@ -53,12 +51,10 @@ class TransferTest extends BuckarooTestCase
      */
     public function it_creates_a_transfer_refund()
     {
-        $response = $this->buckaroo->method('transfer')->refund([
-            'amountCredit' => 10,
-            'invoice' => 'testinvoice 123',
-            'originalTransactionKey' => '2D04704995B74D679AACC59F87XXXXXX',
-        ]);
+        $response = $this->buckaroo->method('transfer')->refund($this->getRefundPayload([
+            'originalTransactionKey' => 'CA18006C913A47E58D830C7D7CC42A6E',
+        ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 }

--- a/tests/Buckaroo/Payments/TrustlyTest.php
+++ b/tests/Buckaroo/Payments/TrustlyTest.php
@@ -29,17 +29,17 @@ class TrustlyTest extends BuckarooTestCase
      */
     public function it_creates_a_trustly_payment()
     {
-        $response = $this->buckaroo->method('trustly')->pay([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
-            'country' => 'DE',
+        $response = $this->buckaroo->method('trustly')->pay($this->getBasePayPayload([], [
+            'country' => 'NL',
+            'continueOnIncomplete'=> true,
             'customer' => [
                 'firstName' => 'Test',
                 'lastName' => 'Aflever',
             ],
-        ]);
 
-        $this->assertTrue($response->isPendingProcessing());
+        ]));
+
+        $this->assertTrue($response->isWaitingOnUserInput());
     }
 
     /**
@@ -47,12 +47,11 @@ class TrustlyTest extends BuckarooTestCase
      */
     public function it_creates_a_trustly_refund()
     {
-        $response = $this->buckaroo->method('trustly')->refund([
-            'amountCredit' => 10,
-            'invoice' => 'testinvoice 123',
-            'originalTransactionKey' => '2D04704995B74D679AACC59F87XXXXXX',
-        ]);
+        $response = $this->buckaroo->method('trustly')->refund($this->getRefundPayload([
+            'originalTransactionKey' => '7F796BBC52664FCA936C4C3A1DD18996',
+        ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 }
+

--- a/tests/Buckaroo/Payments/WeChatPayTest.php
+++ b/tests/Buckaroo/Payments/WeChatPayTest.php
@@ -29,11 +29,9 @@ class WeChatPayTest extends BuckarooTestCase
      */
     public function it_creates_a_wechat_payment()
     {
-        $response = $this->buckaroo->method('wechatpay')->pay([
-            'amountDebit' => 10,
-            'invoice' => uniqid(),
+        $response = $this->buckaroo->method('wechatpay')->pay($this->getBasePayPayload([
             'locale' => 'en-US',
-        ]);
+        ]));
 
         $this->assertTrue($response->isPendingProcessing());
     }
@@ -43,12 +41,10 @@ class WeChatPayTest extends BuckarooTestCase
      */
     public function it_creates_a_wechat_refund()
     {
-        $response = $this->buckaroo->method('wechatpay')->refund([
-            'amountCredit' => 10,
-            'invoice' => 'testinvoice 123',
-            'originalTransactionKey' => '2D04704995B74D679AACC59F87XXXXXX',
-        ]);
+        $response = $this->buckaroo->method('wechatpay')->refund($this->getRefundPayload([
+            'originalTransactionKey' => '67E70539519D427595D86AC50DA4F7CE',
+        ]));
 
-        $this->assertTrue($response->isFailed());
+        $this->assertTrue($response->isSuccess());
     }
 }


### PR DESCRIPTION
Refactored the PHPUnit tests to use a shared payload for consistency.
Previously, tests were passing by only checking for failure, this update improves their reliability.

Note: This PR does not update ApplePayTest and MarketplacesTest.