### PR TITLE
BP-4469-Add-support-for-PHP-8.4

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2, 8.3]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
         stability: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/src/BuckarooClient.php
+++ b/src/BuckarooClient.php
@@ -49,8 +49,9 @@ class BuckarooClient
      * @param string|Config $websiteKey
      * @param string $secretKey
      * @param string|null $mode
+     * @throws BuckarooException
      */
-    public function __construct($websiteKey, string $secretKey = null, string $mode = null)
+    public function __construct($websiteKey, ?string $secretKey = null, ?string $mode = null)
     {
         if ($websiteKey instanceof Config)
         {
@@ -66,10 +67,10 @@ class BuckarooClient
     }
 
     /**
-     * @param string $method
+     * @param string|null $method
      * @return PaymentFacade
      */
-    public function method(string $method = null): PaymentFacade
+    public function method(?string $method = null): PaymentFacade
     {
         return new PaymentFacade($this->client, $method);
     }
@@ -143,8 +144,9 @@ class BuckarooClient
      * @param string $secretKey
      * @param string|null $mode
      * @return Config|null
+     * @throws BuckarooException
      */
-    private function getConfig(string $websiteKey, string $secretKey, string $mode = null): ?Config
+    private function getConfig(string $websiteKey, string $secretKey, ?string $mode = null): ?Config
     {
         if ($websiteKey && $secretKey)
         {

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -142,7 +142,7 @@ abstract class Config implements Loggable
         ?string $moduleVersion = null,
         ?string $culture = null,
         ?string $channel = null,
-        Subject $logger = null,
+        ?Subject $logger = null,
         ?int $timeout = null,
         ?int $connectTimeout = null
     ) {

--- a/src/Exceptions/BuckarooException.php
+++ b/src/Exceptions/BuckarooException.php
@@ -35,7 +35,7 @@ class BuckarooException extends Exception
 
     protected ?Subject $logger;
 
-    public function __construct(?Subject $logger, string $message = "", int $code = 0, Throwable $previous = null)
+    public function __construct(?Subject $logger, string $message = "", int $code = 0, ?Throwable $previous = null)
     {
         $message = $this->message($message);
 

--- a/src/Handlers/Credentials.php
+++ b/src/Handlers/Credentials.php
@@ -60,7 +60,7 @@ class Credentials
 
         try
         {
-            $response = $this->client->specification($request, 'ideal', 2);
+            $response = $this->client->specification('ideal', 2, $request);
         } catch (BuckarooException $e)
         {
             return false;

--- a/src/Services/TraitHelpers/HasIssuers.php
+++ b/src/Services/TraitHelpers/HasIssuers.php
@@ -35,7 +35,7 @@ trait HasIssuers
 
         try
         {
-            $response = $this->client->specification($request, $this->paymentName, $this->serviceVersion());
+            $response = $this->client->specification($this->paymentName, $this->serviceVersion(), $request);
         } catch (BuckarooException $e)
         {
             return [];

--- a/src/Transaction/Client.php
+++ b/src/Transaction/Client.php
@@ -111,9 +111,9 @@ class Client
      * @param $responseClass
      * @return mixed
      */
-    public function get($responseClass = Response::class, string $endPoint = null)
+    public function get($responseClass = Response::class, ?string $endPoint = null)
     {
-        return $this->call(self::METHOD_GET, null, $responseClass, $endPoint);
+        return $this->call(self::METHOD_GET, $responseClass, null, $endPoint);
     }
 
     /**
@@ -121,9 +121,9 @@ class Client
      * @param $responseClass
      * @return mixed
      */
-    public function post(Request $data = null, $responseClass = TransactionResponse::class)
+    public function post(?Request $data = null, $responseClass = TransactionResponse::class)
     {
-        return $this->call(self::METHOD_POST, $data, $responseClass);
+        return $this->call(self::METHOD_POST, $responseClass, $data);
     }
 
     /**
@@ -132,11 +132,11 @@ class Client
      * @return mixed
      * @throws BuckarooException
      */
-    public function dataRequest(Request $data = null, $responseClass = TransactionResponse::class)
+    public function dataRequest(?Request $data = null, $responseClass = TransactionResponse::class)
     {
         $endPoint = $this->getEndpoint('json/DataRequest/');
 
-        return $this->call(self::METHOD_POST, $data, $responseClass, $endPoint);
+        return $this->call(self::METHOD_POST, $responseClass, $data, $endPoint);
     }
 
     /**
@@ -145,11 +145,11 @@ class Client
      * @return mixed
      * @throws BuckarooException
      */
-    public function dataBatchRequest(Request $data = null, $responseClass = TransactionResponse::class)
+    public function dataBatchRequest(?Request $data = null, $responseClass = TransactionResponse::class)
     {
         $endPoint = $this->getEndpoint('json/batch/DataRequests');
 
-        return $this->call(self::METHOD_POST, $data, $responseClass, $endPoint);
+        return $this->call(self::METHOD_POST, $responseClass, $data, $endPoint);
     }
 
     /**
@@ -158,40 +158,40 @@ class Client
      * @return mixed
      * @throws BuckarooException
      */
-    public function transactionBatchRequest(Request $data = null, $responseClass = TransactionResponse::class)
+    public function transactionBatchRequest(?Request $data = null, $responseClass = TransactionResponse::class)
     {
         $endPoint = $this->getEndpoint('json/batch/Transactions');
 
-        return $this->call(self::METHOD_POST, $data, $responseClass, $endPoint);
+        return $this->call(self::METHOD_POST, $responseClass, $data, $endPoint);
     }
 
     /**
-     * @param Request|null $data
      * @param string $paymentName
      * @param int $serviceVersion
+     * @param Request|null $data
      * @return mixed
      * @throws BuckarooException
      */
-    public function specification(Request $data = null, string $paymentName, int $serviceVersion = 0)
+    public function specification(string $paymentName, int $serviceVersion = 0, ?Request $data = null)
     {
         $endPoint = $this->getEndpoint(
             'json/Transaction/Specification/' . $paymentName .
             '?serviceVersion=' . $serviceVersion
         );
 
-        return $this->call(self::METHOD_GET, $data, TransactionResponse::class, $endPoint);
+        return $this->call(self::METHOD_GET, TransactionResponse::class, $data, $endPoint);
     }
 
     /**
      * @param $method
-     * @param Request $data
      * @param string $responseClass
+     * @param Request|null $data
      * @param string|null $endPoint
      * @return mixed
      * @throws BuckarooException
      * @throws \Buckaroo\Exceptions\TransferException
      */
-    protected function call($method, Request $data = null, string $responseClass, string $endPoint = null)
+    protected function call($method, string $responseClass, ?Request $data = null, ?string $endPoint = null)
     {
         $endPoint = $endPoint ?? $this->getTransactionUrl();
 

--- a/src/Transaction/Request/HttpClient/GuzzleHttpClientV5.php
+++ b/src/Transaction/Request/HttpClient/GuzzleHttpClientV5.php
@@ -44,7 +44,7 @@ class GuzzleHttpClientV5 extends HttpClientAbstract
      * @throws BuckarooException|GuzzleException
      */
 
-    public function call(string $url, array $headers, string $method, string $data = null)
+    public function call(string $url, array $headers, string $method, ?string $data = null)
     {
         $headers = $this->convertHeadersFormat($headers);
 

--- a/src/Transaction/Request/HttpClient/GuzzleHttpClientV7.php
+++ b/src/Transaction/Request/HttpClient/GuzzleHttpClientV7.php
@@ -46,7 +46,7 @@ class GuzzleHttpClientV7 extends HttpClientAbstract
      * @throws TransferException
      * @throws BuckarooException
      */
-    public function call(string $url, array $headers, string $method, string $data = null)
+    public function call(string $url, array $headers, string $method, ?string $data = null)
     {
         $headers = $this->convertHeadersFormat($headers);
 

--- a/src/Transaction/Request/HttpClient/HttpClientAbstract.php
+++ b/src/Transaction/Request/HttpClient/HttpClientAbstract.php
@@ -56,7 +56,7 @@ abstract class HttpClientAbstract implements HttpClientInterface
      * @param string|null $data
      * @return mixed
      */
-    abstract public function call(string $url, array $headers, string $method, string $data = null);
+    abstract public function call(string $url, array $headers, string $method, ?string $data = null);
 
     /**
      * @param $result

--- a/src/Transaction/Request/HttpClient/HttpClientInterface.php
+++ b/src/Transaction/Request/HttpClient/HttpClientInterface.php
@@ -31,5 +31,5 @@ interface HttpClientInterface
      * @param string|null $data
      * @return mixed
      */
-    public function call(string $url, array $headers, string $method, string $data = null);
+    public function call(string $url, array $headers, string $method, ?string $data = null);
 }


### PR DESCRIPTION
Add support for nullable types in method signatures for PHP 8.4 compatibility