### PR TITLE
Adds missing parameter to subscription

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "buckaroo/sdk",
     "description": "Buckaroo payment SDK",
     "license": "MIT",
-    "version": "1.21.0",
+    "version": "1.21.1",
     "type": "library",
     "require": {
         "php": ">=7.4|^8.0",

--- a/src/PaymentMethods/Subscriptions/Models/RatePlanCharge.php
+++ b/src/PaymentMethods/Subscriptions/Models/RatePlanCharge.php
@@ -27,6 +27,11 @@ class RatePlanCharge extends ServiceParameter
     /**
      * @var string
      */
+    protected string $ratePlanChargeGuid;
+    
+    /**
+     * @var string
+     */
     protected string $ratePlanChargeCode;
 
     /**


### PR DESCRIPTION
Adds the missing `ratePlanChargeGuid` property to the `RatePlanCharge` model.

Also, increments the version number in composer.json from 1.21.0 to 1.21.1.